### PR TITLE
Fixes #17 - RawMessage and json.Marshaler are now colorized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 .idea
 TODO.md
 **/.DS_Store
+/scratch/


### PR DESCRIPTION
Unfortunately, a side effect is that the keys of JSON from RawMessage and json.Marshaler may sometimes be reordered.