### PR TITLE
Update workflow actions, enable linting

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version-file: go.mod
+        go-version: ">= 1.16"
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [ master, dev ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:
@@ -15,19 +13,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
       with:
-        go-version: ^1.16
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+        go-version-file: go.mod
 
     - name: Get dependencies
       run: |
-        go get -v -t -d ./...
+        go get -v -t ./...
 
     - name: Build
       run: go build -v .

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,60 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Require: The version of golangci-lint to use.
+          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
+          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
+          version: v1.54
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          #
+          # Note: By default, the `.golangci.yml` file should be at the root of the repository.
+          # The location of the configuration file can be changed by using `--config=`
+          # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0
+
+          # We're explicitly setting the exit code to 0 because we don't want the CI to fail
+          # if there are linting errors right now (because there's a bunch of linting errors!)
+          # Ultimately we want to set the exit code to 1.
+          args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true, then all caching functionality will be completely disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true, then the action won't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true, then the action won't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true
+
+          # Optional: The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+          # install-mode: "goinstall"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version-file: go.mod
+          go-version: ">= 1.16"
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,655 +1,334 @@
-# This is a derivative of the .golangci.example.yml as of 9/2021.
+# This code is licensed under the terms of the MIT license.
 
-# This file contains all available configuration options
-# with their default values.
+## Golden config for golangci-lint v1.54
+#
+# This is the best config for golangci-lint based on my experience and opinion.
+# It is very strict, but not extremely strict.
+# Feel free to adopt and change it for your needs.
+#
+# @neilotoole: ^^ Well, it's less strict now!
+# Based on: https://gist.github.com/maratori/47a4d00457a92aa426dbd48a18776322
 
-# options for analysis running
 run:
-  # exit code when at least one issue was found, default is 1
-  issues-exit-code: 1
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 5m
 
-  # include test files or not, default is true
   tests: false
 
+  skip-dirs:
+    - scratch
 
-# all available settings of specific linters
+
+
+
+
+output:
+  sort-results: true
+
+# This file contains only configs which differ from defaults.
+# All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 linters-settings:
-
   cyclop:
-    # the maximal code complexity to report
-    max-complexity: 80
-    # the maximal average package complexity. If it's higher than 0.0 (float) the check is enabled (default 0.0)
-    package-average: 0.0
-    # should ignore tests (default false)
-    skip-tests: true
-
-  dogsled:
-    # checks assignments with too many blank identifiers; default is 2
-    max-blank-identifiers: 2
-
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 100
+    # The maximal code complexity to report.
+    # Default: 10
+    max-complexity: 50
+    # The maximal average package complexity.
+    # If it's higher than 0.0 (float) the check is enabled
+    # Default: 0.0
+    package-average: 10.0
 
   errcheck:
-    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
-    # default is false: such cases aren't reported by default.
-    check-type-assertions: false
-
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-    # default is false: such cases aren't reported by default.
-    check-blank: false
-
-    # [deprecated] comma-separated list of pairs of the form pkg:regex
-    # the regex is used to ignore names within pkg. (default "fmt:.*").
-    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io/ioutil:^Read.*
-
-
-    # list of functions to exclude from checking, where each entry is a single function to exclude.
-    # see https://github.com/kisielk/errcheck#excluding-functions for details
-    exclude-functions:
-      - io/ioutil.ReadFile
-      - io.Copy(*bytes.Buffer)
-      - io.Copy(os.Stdout)
-
-  errorlint:
-    # Check whether fmt.Errorf uses the %w verb for formatting errors. See the readme for caveats
-    errorf: true
-    # Check for plain type assertions and type switches
-    asserts: true
-    # Check for plain error comparisons
-    comparison: true
+    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+    # Such cases aren't reported by default.
+    # Default: false
+    check-type-assertions: true
 
   exhaustive:
-    # check switch statements in generated files also
-    check-generated: false
-    # indicates that switch statements are to be considered exhaustive if a
-    # 'default' case is present, even if all enum members aren't listed in the
-    # switch
-    default-signifies-exhaustive: false
-
-  exhaustivestruct:
-    # Struct Patterns is list of expressions to match struct packages and names
-    # The struct packages have the form example.com/package.ExampleStruct
-    # The matching patterns can use matching syntax from https://pkg.go.dev/path#Match
-    # If this list is empty, all structs are tested.
-    struct-patterns:
-      - '*.Test'
-      - 'example.com/package.ExampleStruct'
-
-  forbidigo:
-    # Forbid the following identifiers (identifiers are written using regexp):
-    forbid:
-#      - ^print.*$
-      - 'fmt\.Print.*'
-    # Exclude godoc examples from forbidigo checks.  Default is true.
-    exclude_godoc_examples: false
+    # Program elements to check for exhaustiveness.
+    # Default: [ switch ]
+    check:
+      - switch
+      - map
 
   funlen:
-    lines: 100
-    statements: 120
-
-  gci:
-    # put imports beginning with prefix after 3rd-party packages;
-    # only support one prefix
-    # if not set, use goimports.local-prefixes
-    local-prefixes: github.com/org/project
+    # Checks the number of lines in a function.
+    # If lower than 0, disable the check.
+    # Default: 60
+    lines: 150
+    # Checks the number of statements in a function.
+    # If lower than 0, disable the check.
+    # Default: 40
+    statements: 100
 
   gocognit:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 80
-
-  goconst:
-    # minimal length of string constant, 3 by default
-    min-len: 3
-    # minimum occurrences of constant string count to trigger issue, 3 by default
-    min-occurrences: 3
-    # ignore test files, false by default
-    ignore-tests: false
-    # look for existing constants matching the values, true by default
-    match-constant: true
-    # search also for duplicated numbers, false by default
-    numbers: false
-    # minimum value, only works with goconst.numbers, 3 by default
-    min: 3
-    # maximum value, only works with goconst.numbers, 3 by default
-    max: 3
-    # ignore when constant is not used as function argument, true by default
-    ignore-calls: true
+    # Minimal code complexity to report
+    # Default: 30 (but we recommend 10-20)
+    min-complexity: 50
 
   gocritic:
-    # Which checks should be enabled; can't be combined with 'disabled-checks';
-    # See https://go-critic.github.io/overview#checks-overview
-    # To check which checks are enabled run `GL_DEBUG=gocritic golangci-lint run`
-    # By default list of stable checks is used.
-    enabled-checks:
-#      - rangeValCopy
-
-    # Which checks should be disabled; can't be combined with 'enabled-checks'; default is empty
-    disabled-checks:
-      - regexpMust
-      - assignOp
-
-    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint run` to see all tags and checks.
-    # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
-    enabled-tags:
-      - performance
-    disabled-tags:
-      - experimental
-
     # Settings passed to gocritic.
     # The settings key is the name of a supported gocritic checker.
     # The list of supported checkers can be find in https://go-critic.github.io/overview.
     settings:
-      captLocal: # must be valid enabled check name
-        # whether to restrict checker to params only (default true)
-        paramsOnly: true
-      elseif:
-        # whether to skip balanced if-else pairs (default true)
-        skipBalanced: true
-      hugeParam:
-        # size in bytes that makes the warning trigger (default 80)
-        sizeThreshold: 80
-#      nestingReduce:
-#        # min number of statements inside a branch to trigger a warning (default 5)
-#        bodyWidth: 5
-      rangeExprCopy:
-        # size in bytes that makes the warning trigger (default 512)
-        sizeThreshold: 512
-        # whether to check test functions (default true)
-        skipTestFuncs: true
-      rangeValCopy:
-        # size in bytes that makes the warning trigger (default 128)
-        sizeThreshold: 32
-        # whether to check test functions (default true)
-        skipTestFuncs: true
-#      ruleguard:
-#        # path to a gorules file for the ruleguard checker
-#        rules: ''
-#      truncateCmp:
-#        # whether to skip int/uint/uintptr types (default true)
-#        skipArchDependent: true
+      captLocal:
+        # Whether to restrict checker to params only.
+        # Default: true
+        paramsOnly: false
       underef:
-        # whether to skip (*x).method() calls where x is a pointer receiver (default true)
-        skipRecvDeref: true
-#      unnamedResult:
-#        # whether to check exported functions
-#        checkExported: true
+        # Whether to skip (*x).method() calls where x is a pointer receiver.
+        # Default: true
+        skipRecvDeref: false
 
   gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 80
-
-  godot:
-    # comments to be checked: `declarations`, `toplevel`, or `all`
-    scope: declarations
-    # list of regexps for excluding particular comment lines from check
-    exclude:
-    # example: exclude comments which contain numbers
-    # - '[0-9]+'
-    # check that each sentence starts with a capital letter
-    capital: false
-
-  godox:
-    # report any comments starting with keywords, this is useful for TODO or FIXME comments that
-    # might be left in the code accidentally and should be resolved before merging
-    keywords: # default keywords are TODO, BUG, and FIXME, these can be overwritten by this setting
-      - NOTE
-      - OPTIMIZE # marks code that should be optimized before merging
-      - HACK # marks hack-arounds that should be removed before merging
-
-  gofmt:
-    # simplify code: gofmt with `-s` option, true by default
-    simplify: true
+    # Minimal code complexity to report.
+    # Default: 30 (but we recommend 10-20)
+    min-complexity: 50
 
   gofumpt:
-    # Select the Go version to target. The default is `1.15`.
-    lang-version: "1.16"
-
-    # Choose whether or not to use the extra rules that are disabled
-    # by default
-    extra-rules: false
-
-  goheader:
-    values:
-      const:
-      # define here const type values in format k:v, for example:
-      # COMPANY: MY COMPANY
-      regexp:
-      # define here regexp type values, for example
-      # AUTHOR: .*@mycompany\.com
-    template: # |-
-    # put here copyright header template for source code files, for example:
-    # Note: {{ YEAR }} is a builtin value that returns the year relative to the current machine time.
-    #
-    # {{ AUTHOR }} {{ COMPANY }} {{ YEAR }}
-    # SPDX-License-Identifier: Apache-2.0
-
-    # Licensed under the Apache License, Version 2.0 (the "License");
-    # you may not use this file except in compliance with the License.
-    # You may obtain a copy of the License at:
-
-    #   http://www.apache.org/licenses/LICENSE-2.0
-
-    # Unless required by applicable law or agreed to in writing, software
-    # distributed under the License is distributed on an "AS IS" BASIS,
-    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    # See the License for the specific language governing permissions and
-    # limitations under the License.
-    template-path:
-    # also as alternative of directive 'template' you may put the path to file with the template source
-
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/org/project
-
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
+    # Module path which contains the source code being formatted.
+    # Default: ""
+    module-path: github.com/neilotoole/jsoncolor
+    # Choose whether to use the extra rules.
+    # Default: false
+    extra-rules: true
 
   gomnd:
-    settings:
-      mnd:
-        # the list of enabled checks, see https://github.com/tommy-muehle/go-mnd/#checks for description.
-        checks: argument,case,condition,operation,return,assign
-        # ignored-numbers: 1000
-        # ignored-files: magic_.*.go
-        # ignored-functions: math.*
-
-  gomoddirectives:
-    # Allow local `replace` directives. Default is false.
-    replace-local: false
-    # List of allowed `replace` directives. Default is empty.
-    replace-allow-list:
-      - launchpad.net/gocheck
-    # Allow to not explain why the version has been retracted in the `retract` directives. Default is false.
-    retract-allow-no-explanation: false
-    # Forbid the use of the `exclude` directives. Default is false.
-    exclude-forbidden: false
+    # List of function patterns to exclude from analysis.
+    # Values always ignored: `time.Date`,
+    # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
+    # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
+    # Default: []
+    ignored-functions:
+      - make
+      - os.Chmod
+      - os.Mkdir
+      - os.MkdirAll
+      - os.OpenFile
+      - os.WriteFile
+      - prometheus.ExponentialBuckets
+      - prometheus.ExponentialBucketsRange
+      - prometheus.LinearBuckets
+    ignored-numbers:
+      - "2"
+      - "3"
 
   gomodguard:
-    allowed:
-      modules:                                                        # List of allowed modules
-      # - gopkg.in/yaml.v2
-      domains:                                                        # List of allowed module domains
-      # - golang.org
     blocked:
-      modules:                                                        # List of blocked modules
-      # - github.com/uudashr/go-module:                             # Blocked module
-      #     recommendations:                                        # Recommended modules that should be used instead (Optional)
-      #       - golang.org/x/mod
-      #     reason: "`mod` is the official go.mod parser library."  # Reason why the recommended module should be used (Optional)
-      versions:                                                       # List of blocked module version constraints
-      # - github.com/mitchellh/go-homedir:                          # Blocked module with version constraint
-      #     version: "< 1.1.0"                                      # Version constraint, see https://github.com/Masterminds/semver#basic-comparisons
-      #     reason: "testing if blocked version constraint works."  # Reason why the version constraint exists. (Optional)
-      local_replace_directives: false                                 # Set to true to raise lint issues for packages that are loaded from a local path via replace directive
-
-  gosec:
-    # To select a subset of rules to run.
-    # Available rules: https://github.com/securego/gosec#available-rules
-    includes:
-      - G401
-      - G306
-      - G101
-    # To specify a set of rules to explicitly exclude.
-    # Available rules: https://github.com/securego/gosec#available-rules
-    excludes:
-      - G204
-    # To specify the configuration of rules.
-    # The configuration of rules is not fully documented by gosec:
-    # https://github.com/securego/gosec#configuration
-    # https://github.com/securego/gosec/blob/569328eade2ccbad4ce2d0f21ee158ab5356a5cf/rules/rulelist.go#L60-L102
-    config:
-      G306: "0600"
-      G101:
-        pattern: "(?i)example"
-        ignore_entropy: false
-        entropy_threshold: "80.0"
-        per_char_threshold: "3.0"
-        truncate: "32"
-
-  gosimple:
-    # Select the Go version to target. The default is '1.13'.
-    go: "1.16"
-    # https://staticcheck.io/docs/options#checks
-    checks: [ "all" ]
+      # List of blocked modules.
+      # Default: []
+      modules:
+        - github.com/golang/protobuf:
+            recommendations:
+              - google.golang.org/protobuf
+            reason: "see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules"
+        - github.com/satori/go.uuid:
+            recommendations:
+              - github.com/google/uuid
+            reason: "satori's package is not maintained"
+        - github.com/gofrs/uuid:
+            recommendations:
+              - github.com/google/uuid
+            reason: "gofrs' package is not go module"
 
   govet:
-    # report about shadowed variables
-    check-shadowing: false
-
-    # settings per analyzer
-    settings:
-      printf: # analyzer name, run `go tool vet help` to see all analyzers
-        funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-
-    # enable or disable analyzers by name
-    # run `go tool vet help` to see all analyzers
-    enable:
-      - atomicalign
-    enable-all: false
+    # Enable all analyzers.
+    # Default: false
+    enable-all: true
+    # Disable analyzers by name.
+    # Run `go tool vet help` to see all analyzers.
+    # Default: []
     disable:
-      - shadow
-    disable-all: false
-
-  depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-      - github.com/sirupsen/logrus
-    packages-with-error-message:
-      # specify an error message to output when a blacklisted package is used
-      - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
-
-  ifshort:
-    # Maximum length of variable declaration measured in number of lines, after which linter won't suggest using short syntax.
-    # Has higher priority than max-decl-chars.
-    max-decl-lines: 1
-    # Maximum length of variable declaration measured in number of characters, after which linter won't suggest using short syntax.
-    max-decl-chars: 30
-
-  importas:
-    # if set to `true`, force to use alias.
-    no-unaliased: true
-    # List of aliases
-    alias:
-      # using `servingv1` alias for `knative.dev/serving/pkg/apis/serving/v1` package
-      - pkg: knative.dev/serving/pkg/apis/serving/v1
-        alias: servingv1
-      # using `autoscalingv1alpha1` alias for `knative.dev/serving/pkg/apis/autoscaling/v1alpha1` package
-      - pkg: knative.dev/serving/pkg/apis/autoscaling/v1alpha1
-        alias: autoscalingv1alpha1
-      # You can specify the package path by regular expression,
-      # and alias by regular expression expansion syntax like below.
-      # see https://github.com/julz/importas#use-regular-expression for details
-      - pkg: knative.dev/serving/pkg/apis/(\w+)/(v[\w\d]+)
-        alias: $1$2
-
-  ireturn:
-    # ireturn allows using `allow` and `reject` settings at the same time.
-    # Both settings are lists of the keywords and regular expressions matched to interface or package names.
-    # keywords:
-    # - `empty` for `interface{}`
-    # - `error` for errors
-    # - `stdlib` for standard library
-    # - `anon` for anonymous interfaces
-
-    # By default, it allows using errors, empty interfaces, anonymous interfaces,
-    # and interfaces provided by the standard library.
-    allow:
-      - anon
-      - error
-      - empty
-      - stdlib
-      # You can specify idiomatic endings for interface
-      - (or|er)$
-
-    # Reject patterns
-    reject:
-      - github.com\/user\/package\/v4\.Type
+      - fieldalignment # too strict
+    # Settings per analyzer.
+    settings:
+      shadow:
+        # Whether to be strict about shadowing; can be noisy.
+        # Default: false
+        strict: false
 
   lll:
-    # max line length, lines longer will be reported. Default is 120.
-    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    # Max line length, lines longer will be reported.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option.
+    # Default: 120.
     line-length: 120
-    # tab width in spaces. Default to 1.
+    # Tab width in spaces.
+    # Default: 1
     tab-width: 1
 
-  makezero:
-    # Allow only slices initialized with a length of zero. Default is false.
-    always: false
-
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
-
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Default is to use a neutral variety of English.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    locale: US
-    ignore-words:
-      - someword
-
   nakedret:
-    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
-    max-func-lines: 30
+    # Make an issue if func has more lines of code than this setting, and it has naked returns.
+    # Default: 30
+    max-func-lines: 0
 
   nestif:
-    # minimal complexity of if statements to report, 5 by default
-    min-complexity: 4
-
-  nilnil:
-    # By default, nilnil checks all returned types below.
-    checked-types:
-      - ptr
-      - func
-      - iface
-      - map
-      - chan
-
-  nlreturn:
-    # size of the block (including return statement that is still "OK")
-    # so no return split required.
-    block-size: 1
+    # Minimal complexity of if statements to report.
+    # Default: 5
+    min-complexity: 20
 
   nolintlint:
-    # Enable to ensure that nolint directives are all used. Default is true.
-    allow-unused: false
-    # Disable to ensure that nolint directives don't have a leading space. Default is true.
-    allow-leading-space: true
-    # Exclude following linters from requiring an explanation.  Default is [].
-    allow-no-explanation: [ ]
-    # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
-    require-explanation: true
-    # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+    # Exclude following linters from requiring an explanation.
+    # Default: []
+    allow-no-explanation: [ funlen, gocognit, lll ]
+    # Enable to require an explanation of nonzero length after each nolint directive.
+    # Default: false
+    require-explanation: false
+    # Enable to require nolint directives to mention the specific linter being suppressed.
+    # Default: false
     require-specific: true
 
-  prealloc:
-    # XXX: we don't recommend using this linter before doing performance profiling.
-    # For most programs usage of prealloc will be a premature optimization.
-
-    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
-    # True by default.
-    simple: true
-    range-loops: true # Report preallocation suggestions on range loops, true by default
-    for-loops: false # Report preallocation suggestions on for loops, false by default
-
-  promlinter:
-    # Promlinter cannot infer all metrics name in static analysis.
-    # Enable strict mode will also include the errors caused by failing to parse the args.
-    strict: false
-    # Please refer to https://github.com/yeya24/promlinter#usage for detailed usage.
-    disabled-linters:
-    #  - "Help"
-    #  - "MetricUnits"
-    #  - "Counter"
-    #  - "HistogramSummaryReserved"
-    #  - "MetricTypeInName"
-    #  - "ReservedChars"
-    #  - "CamelCase"
-    #  - "lintUnitAbbreviations"
-
-  predeclared:
-    # comma-separated list of predeclared identifiers to not report on
-    ignore: ""
-    # include method names and field names (i.e., qualified names) in checks
-    q: false
-
   rowserrcheck:
+    # database/sql is always checked
+    # Default: []
     packages:
-      - github.com/jmoiron/sqlx
+#      - github.com/jmoiron/sqlx
 
-  revive:
-    # see https://github.com/mgechev/revive#available-rules for details.
-    ignore-generated-header: true
-    severity: warning
-    rules:
-      - name: indent-error-flow
-        severity: warning
-      - name: add-constant
-        severity: warning
-        arguments:
-          - maxLitCount: "3"
-            allowStrs: '""'
-            allowInts: "0,1,2"
-            allowFloats: "0.0,0.,1.0,1.,2.0,2."
-
-  staticcheck:
-    # Select the Go version to target. The default is '1.13'.
-    go: "1.16"
-    # https://staticcheck.io/docs/options#checks
-    checks: [ "all",  "-SA1019", "-SA4003","-SA4016" ]
-
-  stylecheck:
-    # Select the Go version to target. The default is '1.13'.
-    go: "1.16"
-    # https://staticcheck.io/docs/options#checks
-    checks: [ "all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022" ]
-    # https://staticcheck.io/docs/options#dot_import_whitelist
-    dot-import-whitelist:
-      - fmt
-    # https://staticcheck.io/docs/options#initialisms
-    initialisms: [ "ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS" ]
-    # https://staticcheck.io/docs/options#http_status_code_whitelist
-    http-status-code-whitelist: [ "200", "400", "404", "500" ]
-
-  tagliatelle:
-    # check the struck tag name case
-    case:
-      # use the struct field name to check the name of the struct tag
-      use-field-name: true
-      rules:
-        # any struct tag type can be used.
-        # support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`
-        json: camel
-        yaml: camel
-        xml: camel
-        bson: camel
-        avro: snake
-        mapstructure: kebab
-
-  testpackage:
-    # regexp pattern to skip files
-    skip-regexp: (export|internal)_test\.go
-
-  thelper:
-    # The following configurations enable all checks. It can be omitted because all checks are enabled by default.
-    # You can enable only required checks deleting unnecessary checks.
-    test:
-      first: true
-      name: true
-      begin: true
-    benchmark:
-      first: true
-      name: true
-      begin: true
-    tb:
-      first: true
-      name: true
-      begin: true
-
-  unparam:
-    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
-
-  unused:
-    # Select the Go version to target. The default is '1.13'.
-    go: "1.16"
-
-  whitespace:
-    multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
-    multi-func: false # Enforces newlines (or comments) after every multi-line function signature
-
-  wrapcheck:
-    # An array of strings that specify substrings of signatures to ignore.
-    # If this set, it will override the default set of ignored signatures.
-    # See https://github.com/tomarrell/wrapcheck#configuration for more information.
-    ignoreSigs:
-      - .Errorf(
-      - errors.New(
-      - errors.Unwrap(
-      - .Wrap(
-      - .Wrapf(
-      - .WithMessage(
-      - .WithMessagef(
-      - .WithStack(
-    ignorePackageGlobs:
-      - encoding/*
-      - github.com/pkg/*
-
-  wsl:
-    # See https://github.com/bombsimon/wsl/blob/master/doc/configuration.md for
-    # documentation of available settings. These are the defaults for
-    # `golangci-lint`.
-    allow-assign-and-anything: false
-    allow-assign-and-call: true
-    allow-cuddle-declarations: false
-    allow-multiline-assign: true
-    allow-separated-leading-comment: false
-    allow-trailing-comment: false
-    force-case-trailing-whitespace: 0
-    force-err-cuddling: false
-    force-short-decl-cuddling: false
-    strict-append: true
-
+  tenv:
+    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
+    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
+    # Default: false
+    all: true
 
 
 linters:
-#  disable-all: true
-#  enable:
-#    - megacheck
-#    - govet
-  enable-all: true
-  disable:
-    - deadcode
-    - dupl
-    - errorlint
-    - exhaustive
-    - forcetypeassert
-    - funlen
-    - gci
-    - gochecknoglobals
-    - gochecknoinits
-    - gocritic
-    - godox
-    - goerr113
-    - gofmt
-    - gofumpt
-    - gomnd
-    - ifshort
-    - interfacer
-    - lll
-    - maligned
-    - nakedret
-    - nestif
-    - nilerr
-    - nlreturn
-    - predeclared
-    - revive
-    - scopelint
-    - structcheck
-    - unconvert
-    - unparam
-    - unused
-    - whitespace
-    - wrapcheck
-    - wsl
+  disable-all: true
 
-    # to be re-enabled
-    - golint
-#  presets:
-#    - bugs
-#    - unused
-#  fast: false
+  enable:
+    ## enabled by default
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - gosimple # specializes in simplifying a code
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign # detects when assignments to existing variables are not used
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
+    - unused # checks for unused constants, variables, functions and types
+
+
+    #    ## disabled by default
+    - asasalint # checks for pass []any as any in variadic func(...any)
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - cyclop # checks function and package cyclomatic complexity
+    - dupl # tool for code clone detection
+    - durationcheck # checks for two durations multiplied together
+    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
+    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+    - execinquery # checks query string in Query function which reads your Go src files and warning it finds
+    - exhaustive # checks exhaustiveness of enum switch statements
+    - exportloopref # checks for pointers to enclosing loop variables
+    - forbidigo # forbids identifiers
+    - funlen # tool for detection of long functions
+    - gochecknoinits # checks that no init functions are present in Go code
+    - gocognit # computes and checks the cognitive complexity of functions
+    - goconst # finds repeated strings that could be replaced by a constant
+    - gocritic # provides diagnostics that check for bugs, performance and style issues
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    - godot # checks if comments end in a period
+    - gofumpt
+    - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
+    #    - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - gosec # inspects source code for security problems
+    - lll # reports long lines
+    - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
+    - makezero # finds slice declarations with non-zero initial length
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nestif # reports deeply nested if statements
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
+    - noctx # finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
+    - predeclared # finds code that shadows one of Go's predeclared identifiers
+    - promlinter # checks Prometheus metrics naming via promlint
+    - reassign # checks that package variables are not reassigned
+    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
+    - stylecheck # is a replacement for golint
+    - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
+    - testableexamples # checks if examples are testable (have an expected output)
+    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
+    - whitespace # detects leading and trailing whitespace
+
+    ## These three linters are disabled for now due to generics: https://github.com/golangci/golangci-lint/issues/2649
+    #- rowserrcheck # checks whether Err of rows is checked successfully  # Disabled because:  https://github.com/golangci/golangci-lint/issues/2649
+    #- sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    #- wastedassign # finds wasted assignment statements
+
+
+    ## you may want to enable
+    #- decorder # checks declaration order and count of types, constants, variables and functions
+    #- exhaustruct # checks if all structure fields are initialized
+    #- gochecknoglobals # checks that no global variables exist
+    #- godox # detects FIXME, TODO and other comment keywords
+    #- goheader # checks is file header matches to pattern
+    #- gomnd # detects magic numbers
+    #- interfacebloat # checks the number of methods inside an interface
+    #- ireturn # accept interfaces, return concrete types
+    #- prealloc # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
+    #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
+    #- wrapcheck # checks that errors returned from external packages are wrapped
+
+    ## disabled
+    #- containedctx # detects struct contained context.Context field
+    #- contextcheck # [too many false positives] checks the function whether use a non-inherited context
+    #- depguard # [replaced by gomodguard] checks if package imports are in a list of acceptable packages
+    #- dogsled # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
+    #- dupword # [useless without config] checks for duplicate words in the source code
+    #- errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted
+    #- forcetypeassert # [replaced by errcheck] finds forced type assertions
+    #- goerr113 # [too strict] checks the errors handling expressions
+    #- gofmt # [replaced by goimports] checks whether code was gofmt-ed
+    #- gofumpt # [replaced by goimports, gofumports is not available yet] checks whether code was gofumpt-ed
+    #- grouper # analyzes expression groups
+    #- importas # enforces consistent import aliases
+    #- maintidx # measures the maintainability index of each function
+    #- misspell # [useless] finds commonly misspelled English words in comments
+    #- nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
+    #- paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
+    #- tagliatelle # checks the struct tags
+    #- thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    #- wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
+
+    ## deprecated
+    #- deadcode # [deprecated, replaced by unused] finds unused code
+    #- exhaustivestruct # [deprecated, replaced by exhaustruct] checks if all struct's fields are initialized
+    #- golint # [deprecated, replaced by revive] golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
+    #- ifshort # [deprecated] checks that your code uses short syntax for if-statements whenever possible
+    #- interfacer # [deprecated] suggests narrower interface types
+    #- maligned # [deprecated, replaced by govet fieldalignment] detects Go structs that would take less memory if their fields were sorted
+    #- nosnakecase # [deprecated, replaced by revive var-naming] detects snake case of variable naming and function name
+    #- scopelint # [deprecated, replaced by exportloopref] checks for unpinned variables in go programs
+    #- structcheck # [deprecated, replaced by unused] finds unused struct fields
+    #- varcheck # [deprecated, replaced by unused] finds unused global variables and constants
+
+
+issues:
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 3
+
+  exclude-rules:
+    - source: "^//\\s*go:generate\\s"
+      linters: [ lll ]
+    - source: "(noinspection|TODO)"
+      linters: [ godot ]
+    - source: "//noinspection"
+      linters: [ gocritic ]
+    - source: "^\\s+if _, ok := err\\.\\([^.]+\\.InternalError\\); ok {"
+      linters: [ errorlint ]
+    - path: "_test\\.go"
+      linters:
+        - bodyclose
+        - dupl
+        - funlen
+        - goconst
+        - gosec
+        - noctx
+        - wrapcheck
 


### PR DESCRIPTION
- The GH workflow was showing [deprecation warnings](https://github.com/neilotoole/jsoncolor/actions/runs/6827060658) due to use of old actions. The actions have been updated to latest versions.
- Added `golangci-lint` workflow. There's a bunch of lint errors, which we don't attempt to address in this PR. For that reason, the workflow doesn't fail on lint errors (`--issues-exit-code=0`). Ultimately we will want to change this so that the workflow does fail on errors, after we've addressed the present batch of lint issues.
- The `.golangci.yml` config file has been updated. This is largely a copy of a "golden config" from my [`sq`](https://github.com/neiltoole/sq) project. But the config hasn't really been adapted specifically for `jsoncolor`. That's something that should be done at some point.