### PR TITLE
improve IsColorTerminal windows support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,14 @@ go 1.16
 require (
 	github.com/fatih/color v1.16.0
 	github.com/mattn/go-colorable v0.1.13
-	github.com/mattn/go-isatty v0.0.20
+	golang.org/x/sys v0.14.0
+	golang.org/x/term v0.14.0
 )
 
 require (
-	// Only used for test/benchmark/comparision.
+	// Only used for test/benchmark/comparison.
 	github.com/nwidger/jsoncolor v0.3.2
-	// Only used for test/benchmark/comparision.
+	// Only used for test/benchmark/comparison.
 	github.com/segmentio/encoding v0.3.6
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.14.0 h1:LGK9IlZ8T9jvdy6cTdfKUCltatMFOehAQo9SRC46UQ8=
+golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/jsoncolor.go
+++ b/jsoncolor.go
@@ -1,11 +1,7 @@
 package jsoncolor
 
 import (
-	"io"
-	"os"
 	"strconv"
-
-	"github.com/mattn/go-isatty"
 )
 
 // Colors specifies colorization of JSON output. Each field
@@ -117,11 +113,11 @@ func (c *Colors) appendPunc(b []byte, v byte) []byte {
 // Color is used to render terminal colors. In effect, Color is
 // the bytes of the ANSI prefix code. The zero value is valid (results in
 // no colorization). When Color is non-zero, the encoder writes the prefix,
-//then the actual value, then the ANSI reset code.
+// then the actual value, then the ANSI reset code.
 //
 // Example value:
 //
-//  number := Color("\x1b[36m")
+//	number := Color("\x1b[36m")
 type Color []byte
 
 // ansiReset is the ANSI ansiReset escape code.
@@ -142,32 +138,4 @@ func DefaultColors() *Colors {
 		Punc:          Color{},           // No colorization
 		TextMarshaler: Color("\x1b[32m"), // Same as String
 	}
-}
-
-// IsColorTerminal returns true if w is a colorable terminal.
-func IsColorTerminal(w io.Writer) bool {
-	// This logic could be pretty dodgy; use at your own risk.
-	if w == nil {
-		return false
-	}
-
-	f, ok := w.(*os.File)
-	if !ok {
-		return false
-	}
-	fd := f.Fd()
-
-	if !isatty.IsTerminal(fd) {
-		return false
-	}
-
-	if os.Getenv("TERM") == "dumb" {
-		return false
-	}
-
-	if isatty.IsCygwinTerminal(fd) {
-		return false
-	}
-
-	return true
 }

--- a/terminal.go
+++ b/terminal.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package jsoncolor
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// IsColorTerminal returns true if w is a colorable terminal.
+// It respects [NO_COLOR], [FORCE_COLOR] and TERM=dumb environment variables.
+//
+// [NO_COLOR]: https://no-color.org/
+// [FORCE_COLOR]: https://force-color.org/
+func IsColorTerminal(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	if os.Getenv("FORCE_COLOR") != "" {
+		return true
+	}
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+
+	if w == nil {
+		return false
+	}
+
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+
+	if !term.IsTerminal(int(f.Fd())) {
+		return false
+	}
+
+	return true
+}

--- a/terminal_windows.go
+++ b/terminal_windows.go
@@ -1,0 +1,53 @@
+package jsoncolor
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// IsColorTerminal returns true if w is a colorable terminal.
+// It respects [NO_COLOR], [FORCE_COLOR] and TERM=dumb environment variables.
+//
+// [NO_COLOR]: https://no-color.org/
+// [FORCE_COLOR]: https://force-color.org/
+func IsColorTerminal(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	if os.Getenv("FORCE_COLOR") != "" {
+		return true
+	}
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+
+	if w == nil {
+		return false
+	}
+
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	fd := f.Fd()
+
+	console := windows.Handle(fd)
+	var mode uint32
+	if err := windows.GetConsoleMode(console, &mode); err != nil {
+		return false
+	}
+
+	var want uint32 = windows.ENABLE_PROCESSED_OUTPUT | windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING
+	if (mode & want) == want {
+		return true
+	}
+
+	mode |= want
+	if err := windows.SetConsoleMode(console, mode); err != nil {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
### Changes

- add separate `IsColorTerminal` implementation for Windows
  - checks for the `ENABLE_VIRTUAL_TERMINAL_PROCESSING` flag, to see if ANSI colors are supported (https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences)
  - also checks for `ENABLE_PROCESSED_OUTPUT`, since that should be set when `ENABLE_VIRTUAL_TERMINAL_PROCESSING` is set (https://learn.microsoft.com/en-us/windows/console/setconsolemode#parameters)
  - similar implementation as [`libuv`](https://github.com/libuv/libuv/blob/71ffdec4fdf93d6b251f78e384e8cc4296c70d44/src/win/tty.c#L2308) (used by Node.js)
- add checks for the [NO_COLOR](https://no-color.org/) and [FORCE_COLOR](https://force-color.org/) environment variables
- remove `IsCygwinTerminal` check
  - this is redundant, since `windows.GetConsoleMode` already fails for such terminals, so the behavior is the same (tested this on my Windows machine)
  - this lets us drop the dependency on `go-isatty` in favor of `golang.org/x/term` - I would say that golang.org dependencies are preferable
- fix minor typos and formatting in `go.mod` and `jsoncolor.go` 