### PR TITLE
Fix TestCodec failure on Go 1.22+ and update CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,15 +12,19 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        # go1.17 is the minimum version specified in go.mod. The newer
+        # versions verify the package still compiles and passes tests
+        # on recent toolchains.
+        go-version: ['1.17', '1.24', '1.26']
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
-        go-version: ">= 1.16"
+        go-version: ${{ matrix.go-version }}
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,45 +17,19 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: ">= 1.16"
+          go-version: "1.22"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        # v6 is the last version to support golangci-lint v1.x; v7+ requires v2 only.
+        uses: golangci/golangci-lint-action@v6
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
           version: v1.54
 
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          #
-          # Note: By default, the `.golangci.yml` file should be at the root of the repository.
-          # The location of the configuration file can be changed by using `--config=`
-          # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0
-
-          # We're explicitly setting the exit code to 0 because we don't want the CI to fail
-          # if there are linting errors right now (because there's a bunch of linting errors!)
-          # Ultimately we want to set the exit code to 1.
           args: --issues-exit-code=1 --out-format=colored-line-number
 
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true, then all caching functionality will be completely disabled,
-          #           takes precedence over all other caching options.
-          # skip-cache: true
-
-          # Optional: if set to true, then the action won't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true, then the action won't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
-
-          # Optional: The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
-          # install-mode: "goinstall"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ From the example [`jc`](./cmd/jc/main.go) app:
 
 ## Usage
 
-Get the package per the normal mechanism (requires Go 1.16+):
+Get the package per the normal mechanism (requires Go 1.17+):
 
 ```shell
 go get -u github.com/neilotoole/jsoncolor

--- a/example_test.go
+++ b/example_test.go
@@ -46,9 +46,9 @@ func ExampleEncoder() {
 	}
 }
 
-// ExampleFatihColor shows use of the fatihcolor helper package
+// Example_fatihColor shows use of the fatihcolor helper package
 // with jsoncolor.
-func ExampleFatihColor() {
+func Example_fatihColor() {
 	var enc *json.Encoder
 
 	// Note: this check will fail if running inside Goland (and

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,20 @@
 module github.com/neilotoole/jsoncolor
 
-go 1.16
+go 1.17
 
 require (
 	github.com/fatih/color v1.16.0
 	github.com/mattn/go-colorable v0.1.13
 	golang.org/x/sys v0.14.0
 	golang.org/x/term v0.14.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (


### PR DESCRIPTION
> **Note:** This PR does the bare minimum upgrading to address #38. Notably, `go.mod` is only bumped to Go 1.17. A future PR will be required to bump the minimum Go version to something more recent.

## Summary
- Use semantic JSON comparison (`jsonBytesEqual`) in `TestCodec` instead of `bytes.Equal`, fixing the test failure caused by Go 1.22+'s stdlib encoder emitting `\b`/`\f` instead of `\u0008`/`\u000c` (CL 521675)
- Rename `ExampleFatihColor` → `Example_fatihColor` to satisfy Go 1.24 vet
- Bump `go.mod` minimum from Go 1.16 to 1.17
- Expand CI test matrix to Go 1.17, 1.24, and 1.26 across all OS targets
- Update golangci-lint workflow: `actions/checkout` v3→v4, `actions/setup-go` v4→v5, `golangci-lint-action` v3→v6 (last version supporting golangci-lint v1.x), pin Go 1.22 for v1.54 compatibility

Addresses #38

## Test plan
- [x] `go test ./...` passes locally
- [x] `go vet ./...` — no new warnings
- [x] CI passes on Go 1.17, 1.24, and 1.26 across all OS targets
- [x] golangci-lint CI job passes