### PR TITLE
Export Indenter type and NewIndenter constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ the codebases have drifted significantly by now.
 
 ### [v0.8.0](https://github.com/neilotoole/jsoncolor/releases/tag/v0.8.0)
 
+- [#37](https://github.com/neilotoole/jsoncolor/issues/37): Exported the `indenter` type (now `Indenter`) and added the `NewIndenter` constructor, so external callers can construct the indenter argument accepted by `Append`. The `Append` signature now reads `Append(b []byte, x interface{}, flags AppendFlags, clrs *Colors, indentr *Indenter)`.
 - Bumped minimum Go version from 1.17 to 1.25.
 - Updated dependencies to latest: `fatih/color` v1.19.0, `mattn/go-colorable` v0.1.14, `golang.org/x/sys` v0.45.0, and `golang.org/x/term` v0.43.0 (plus test-only `stretchr/testify` v1.11.1 and `segmentio/encoding` v0.5.4).
 - Migrated the `golangci-lint` config to the v2 format; CI now runs `golangci-lint` v2.12.2 (action `v8`) and the test matrix targets Go 1.25 and 1.26.

--- a/codec.go
+++ b/codec.go
@@ -23,7 +23,7 @@ type codec struct {
 type encoder struct {
 	flags   AppendFlags
 	clrs    *Colors
-	indentr *indenter
+	indentr *Indenter
 }
 type decoder struct{ flags ParseFlags }
 

--- a/encode.go
+++ b/encode.go
@@ -999,22 +999,27 @@ func appendCompactEscapeHTML(dst, src []byte) []byte {
 	return dst
 }
 
-// indenter is used to indent JSON. The push and pop methods
-// change indentation level. The appendIndent method appends the
-// computed indentation. The appendByte method appends a byte. All
-// methods are safe to use with a nil receiver.
-type indenter struct {
+// Indenter is used to indent JSON, controlling the prefix and indent
+// strings applied at each nesting level. Construct an Indenter with
+// [NewIndenter], and pass it (or nil for no indentation) to [Append].
+//
+// A nil *Indenter is valid and disables indentation, producing compact
+// output. All Indenter methods are safe to use with a nil receiver.
+type Indenter struct {
 	disabled bool
 	prefix   string
 	indent   string
 	depth    int
 }
 
-// newIndenter returns a new indenter instance. If prefix and
-// indent are both empty, the indenter is effectively disabled,
-// and the appendIndent and appendByte methods are no-op.
-func newIndenter(prefix, indent string) *indenter {
-	return &indenter{
+// NewIndenter returns a new Indenter instance for use with [Append]. The
+// prefix is prepended to each indented line, and indent is repeated once
+// per nesting level, matching the semantics of [Encoder.SetIndent] and
+// [encoding/json.Encoder.SetIndent]. If prefix and indent are both empty,
+// the Indenter is effectively disabled, and the resulting JSON is compact
+// (equivalent to passing a nil *Indenter to Append).
+func NewIndenter(prefix, indent string) *Indenter {
+	return &Indenter{
 		disabled: prefix == "" && indent == "",
 		prefix:   prefix,
 		indent:   indent,
@@ -1022,22 +1027,22 @@ func newIndenter(prefix, indent string) *indenter {
 }
 
 // push increases the indentation level.
-func (in *indenter) push() {
+func (in *Indenter) push() {
 	if in != nil {
 		in.depth++
 	}
 }
 
 // pop decreases the indentation level.
-func (in *indenter) pop() {
+func (in *Indenter) pop() {
 	if in != nil {
 		in.depth--
 	}
 }
 
-// appendByte appends a to b if the indenter is non-nil and enabled.
+// appendByte appends a to b if the Indenter is non-nil and enabled.
 // Otherwise b is returned unmodified.
-func (in *indenter) appendByte(b []byte, a byte) []byte {
+func (in *Indenter) appendByte(b []byte, a byte) []byte {
 	if in == nil || in.disabled {
 		return b
 	}
@@ -1046,8 +1051,8 @@ func (in *indenter) appendByte(b []byte, a byte) []byte {
 }
 
 // appendIndent writes indentation to b, returning the resulting slice.
-// If the indenter is nil or disabled b is returned unchanged.
-func (in *indenter) appendIndent(b []byte) []byte {
+// If the Indenter is nil or disabled b is returned unchanged.
+func (in *Indenter) appendIndent(b []byte) []byte {
 	if in == nil || in.disabled {
 		return b
 	}

--- a/json.go
+++ b/json.go
@@ -115,7 +115,11 @@ const (
 
 // Append acts like Marshal but appends the json representation to b instead of
 // always reallocating a new slice.
-func Append(b []byte, x interface{}, flags AppendFlags, clrs *Colors, indentr *indenter) ([]byte, error) {
+//
+// The indentr argument controls indentation. Pass nil for compact output, or
+// construct an [Indenter] via [NewIndenter] to indent the output. The clrs
+// argument may be nil to disable colorization.
+func Append(b []byte, x interface{}, flags AppendFlags, clrs *Colors, indentr *Indenter) ([]byte, error) {
 	if x == nil {
 		// Special case for nil values because it makes the rest of the code
 		// simpler to assume that it won't be seeing nil pointers.
@@ -373,7 +377,7 @@ type Encoder struct {
 	err     error
 	flags   AppendFlags
 	clrs    *Colors
-	indentr *indenter
+	indentr *Indenter
 }
 
 // NewEncoder is documented at https://golang.org/pkg/encoding/json/#NewEncoder
@@ -423,7 +427,7 @@ func (enc *Encoder) SetEscapeHTML(on bool) {
 
 // SetIndent is documented at https://golang.org/pkg/encoding/json/#Encoder.SetIndent
 func (enc *Encoder) SetIndent(prefix, indent string) {
-	enc.indentr = newIndenter(prefix, indent)
+	enc.indentr = NewIndenter(prefix, indent)
 }
 
 // SetSortMapKeys is an extension to the standard encoding/json package which

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -594,3 +594,33 @@ func TestEncode_TextMarshaler(t *testing.T) {
 	require.Equal(t, "\x1b[36m\"example text\"\x1b[0m\n", buf.String(),
 		"expected TextMarshaler encoding to use Colors.TextMarshaler")
 }
+
+// TestAppendIndenter verifies that an external caller can construct an
+// Indenter via the exported NewIndenter constructor and pass it to the
+// exported Append function. See issue #37.
+func TestAppendIndenter(t *testing.T) {
+	m := map[string]interface{}{"a": 1}
+
+	// A nil *Indenter produces compact output.
+	var nilIndenter *jsoncolor.Indenter
+	b, err := jsoncolor.Append(nil, m, jsoncolor.EscapeHTML|jsoncolor.SortMapKeys, nil, nilIndenter)
+	require.NoError(t, err)
+	require.Equal(t, `{"a":1}`, string(b))
+
+	// An Indenter constructed via NewIndenter indents the output, matching
+	// the behavior of encoding/json.MarshalIndent.
+	indentr := jsoncolor.NewIndenter("", "  ")
+	b, err = jsoncolor.Append(nil, m, jsoncolor.EscapeHTML|jsoncolor.SortMapKeys, nil, indentr)
+	require.NoError(t, err)
+
+	want, err := stdjson.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	require.Equal(t, string(want), string(b))
+
+	// NewIndenter with empty prefix and indent is equivalent to a nil
+	// Indenter, producing compact output.
+	disabled := jsoncolor.NewIndenter("", "")
+	b, err = jsoncolor.Append(nil, m, jsoncolor.EscapeHTML|jsoncolor.SortMapKeys, nil, disabled)
+	require.NoError(t, err)
+	require.Equal(t, `{"a":1}`, string(b))
+}


### PR DESCRIPTION
Closes #37.

`Append` accepted an `*indenter` argument whose type was unexported, with only an unexported `newIndenter` constructor — so external callers could never construct a non-nil indenter and could not use `Append`'s indentation support.

## Changes
- Rename `indenter` → `Indenter` and `newIndenter` → `NewIndenter` (exported), updating `Append`'s signature.
- Add an external (`package jsoncolor_test`) test demonstrating construction via `NewIndenter` and use with `Append`.
- Document construction on `Append`, `Indenter`, and `NewIndenter`.

Backward compatible: callers outside the package could previously only pass `nil` for this argument, and `nil` remains valid.

Verified: `go build ./...`, `go test ./...`, and `golangci-lint run ./...` all clean.