### PR TITLE
Add granular punctuation color fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ the codebases have drifted significantly by now.
 
 ### [v0.8.0](https://github.com/neilotoole/jsoncolor/releases/tag/v0.8.0)
 
+- [#16](https://github.com/neilotoole/jsoncolor/issues/16): Add individually-configurable punctuation color fields — `Colors.Brackets`, `Colors.Braces`, `Colors.Comma`, and `Colors.Colon` — each falling back to `Colors.Punc` when unset, so existing configs are unaffected.
 - Bumped minimum Go version from 1.17 to 1.25.
 - Updated dependencies to latest: `fatih/color` v1.19.0, `mattn/go-colorable` v0.1.14, `golang.org/x/sys` v0.45.0, and `golang.org/x/term` v0.43.0 (plus test-only `stretchr/testify` v1.11.1 and `segmentio/encoding` v0.5.4).
 - Migrated the `golangci-lint` config to the v2 format; CI now runs `golangci-lint` v2.12.2 (action `v8`) and the test matrix targets Go 1.25 and 1.26.

--- a/jsoncolor.go
+++ b/jsoncolor.go
@@ -28,8 +28,38 @@ type Colors struct {
 	// Time is the color for datetime values.
 	Time Color
 
-	// Punc is the color for JSON punctuation: []{},: etc.
+	// Punc is the color for JSON punctuation: the structural
+	// characters [ ] { } , and : .
+	//
+	// Punc acts as the fallback color for all punctuation. The more
+	// specific fields below (Brackets, Braces, Comma, Colon) override
+	// Punc for their respective characters; when one of those fields is
+	// the zero value (unset), the encoder falls back to Punc. Therefore
+	// code that sets only Punc continues to colorize all punctuation
+	// exactly as before.
+	//
+	// Note that the structural double-quote characters that delimit JSON
+	// strings and keys are not controlled by Punc; they are colored by
+	// the String and Key fields respectively.
 	Punc Color
+
+	// Brackets is the color for array bracket punctuation: [ and ] .
+	// When unset (the zero value), it falls back to Punc.
+	Brackets Color
+
+	// Braces is the color for object brace punctuation: { and } .
+	// When unset (the zero value), it falls back to Punc.
+	Braces Color
+
+	// Comma is the color for the comma punctuation that separates
+	// array elements and object members: , .
+	// When unset (the zero value), it falls back to Punc.
+	Comma Color
+
+	// Colon is the color for the colon punctuation that separates
+	// object keys from their values: : .
+	// When unset (the zero value), it falls back to Punc.
+	Colon Color
 
 	// TextMarshaler is the color for values implementing encoding.TextMarshaler.
 	TextMarshaler Color
@@ -88,15 +118,42 @@ func (c *Colors) appendUint64(b []byte, v uint64) []byte {
 	return append(b, ansiReset...)
 }
 
-// appendPunc appends the colorized punctuation mark v to b.
+// appendPunc appends the colorized punctuation mark v to b. The color is
+// chosen by puncColor, which selects the granular field corresponding to v
+// (Brackets, Braces, Comma, Colon), falling back to Punc when that field is
+// unset.
 func (c *Colors) appendPunc(b []byte, v byte) []byte {
 	if c == nil {
 		return append(b, v)
 	}
 
-	b = append(b, c.Punc...)
+	b = append(b, c.puncColor(v)...)
 	b = append(b, v)
 	return append(b, ansiReset...)
+}
+
+// puncColor returns the Color to use for punctuation mark v. It selects the
+// granular field that governs v: Brackets for [ and ], Braces for { and },
+// Comma for , and Colon for : . When the selected granular field is the zero
+// value (unset), it falls back to Punc. This preserves backward compatibility
+// for callers that set only Punc.
+func (c *Colors) puncColor(v byte) Color {
+	var clr Color
+	switch v {
+	case '[', ']':
+		clr = c.Brackets
+	case '{', '}':
+		clr = c.Braces
+	case ',':
+		clr = c.Comma
+	case ':':
+		clr = c.Colon
+	}
+
+	if len(clr) == 0 {
+		return c.Punc
+	}
+	return clr
 }
 
 // Color is used to render terminal colors. In effect, Color is
@@ -117,14 +174,18 @@ const ansiReset = "\x1b[0m"
 // with some deviation.
 func DefaultColors() *Colors {
 	return &Colors{
-		Null:          Color("\x1b[2m"),
-		Bool:          Color("\x1b[1m"),
-		Number:        Color("\x1b[36m"),
-		String:        Color("\x1b[32m"),
-		Key:           Color("\x1b[34;1m"),
-		Bytes:         Color("\x1b[2m"),
-		Time:          Color("\x1b[32;2m"),
-		Punc:          Color{},           // No colorization
+		Null:   Color("\x1b[2m"),
+		Bool:   Color("\x1b[1m"),
+		Number: Color("\x1b[36m"),
+		String: Color("\x1b[32m"),
+		Key:    Color("\x1b[34;1m"),
+		Bytes:  Color("\x1b[2m"),
+		Time:   Color("\x1b[32;2m"),
+		Punc:   Color{}, // No colorization
+		// The granular punctuation fields (Brackets, Braces, Comma,
+		// Colon) are intentionally left as the zero value so that they
+		// fall back to Punc, preserving the default (uncolored)
+		// punctuation behavior.
 		TextMarshaler: Color("\x1b[32m"), // Same as String
 	}
 }

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -594,3 +594,118 @@ func TestEncode_TextMarshaler(t *testing.T) {
 	require.Equal(t, "\x1b[36m\"example text\"\x1b[0m\n", buf.String(),
 		"expected TextMarshaler encoding to use Colors.TextMarshaler")
 }
+
+// puncEncode encodes v with the given Colors and returns the output, using
+// no-HTML-escaping and sorted map keys so output is deterministic.
+func puncEncode(t *testing.T, clrs *jsoncolor.Colors, v interface{}) string {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	enc := jsoncolor.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	enc.SetSortMapKeys(true)
+	enc.SetIndent("", "  ")
+	enc.SetColors(clrs)
+	require.NoError(t, enc.Encode(v))
+	return buf.String()
+}
+
+// TestEncode_Punc_OnlyPunc verifies the backward-compatible behavior: when only
+// Colors.Punc is set, all punctuation ([ ] { } , :) is colored with Punc.
+func TestEncode_Punc_OnlyPunc(t *testing.T) {
+	const punc = "\x1b[1m" // bold
+	clrs := &jsoncolor.Colors{Punc: jsoncolor.Color(punc)}
+
+	// Object inside an array exercises [ ] { } , and : .
+	v := []interface{}{
+		map[string]interface{}{"a": 1, "b": 2},
+		3,
+	}
+
+	got := puncEncode(t, clrs, v)
+
+	const reset = "\x1b[0m"
+	// When colors are enabled, keys and scalar values render with an
+	// (empty) color prefix followed by a reset suffix.
+	key := func(s string) string { return "\"" + s + "\"" + reset }
+	val := func(s string) string { return s + reset }
+	// Every structural punctuation char is wrapped with the Punc color.
+	want := punc + "[" + reset + "\n  " +
+		punc + "{" + reset + "\n    " +
+		key("a") + punc + ":" + reset + " " + val("1") + punc + "," + reset + "\n    " +
+		key("b") + punc + ":" + reset + " " + val("2") + "\n  " +
+		punc + "}" + reset + punc + "," + reset + "\n  " +
+		val("3") + "\n" +
+		punc + "]" + reset + "\n"
+
+	require.Equal(t, want, got,
+		"setting only Punc should color all punctuation identically")
+}
+
+// TestEncode_Punc_GranularOverride verifies that a granular field overrides only
+// its punctuation class, while the remaining classes fall back to Punc.
+func TestEncode_Punc_GranularOverride(t *testing.T) {
+	const (
+		punc     = "\x1b[1m"  // bold (fallback)
+		brackets = "\x1b[31m" // red (override for [ ])
+		reset    = "\x1b[0m"
+	)
+	clrs := &jsoncolor.Colors{
+		Punc:     jsoncolor.Color(punc),
+		Brackets: jsoncolor.Color(brackets),
+	}
+
+	v := []interface{}{
+		map[string]interface{}{"a": 1},
+	}
+
+	got := puncEncode(t, clrs, v)
+
+	key := func(s string) string { return "\"" + s + "\"" + reset }
+	val := func(s string) string { return s + reset }
+	// Brackets use the granular color; braces, comma and colon fall back to Punc.
+	want := brackets + "[" + reset + "\n  " +
+		punc + "{" + reset + "\n    " +
+		key("a") + punc + ":" + reset + " " + val("1") + "\n  " +
+		punc + "}" + reset + "\n" +
+		brackets + "]" + reset + "\n"
+
+	require.Equal(t, want, got,
+		"Brackets should override only [ and ]; other punctuation falls back to Punc")
+}
+
+// TestEncode_Punc_AllGranular verifies that each granular field governs exactly
+// its own punctuation class when all of them are set.
+func TestEncode_Punc_AllGranular(t *testing.T) {
+	const (
+		brackets = "\x1b[31m" // [ ]
+		braces   = "\x1b[32m" // { }
+		comma    = "\x1b[33m" // ,
+		colon    = "\x1b[34m" // :
+		reset    = "\x1b[0m"
+	)
+	clrs := &jsoncolor.Colors{
+		// Punc deliberately unset; every class has its own color.
+		Brackets: jsoncolor.Color(brackets),
+		Braces:   jsoncolor.Color(braces),
+		Comma:    jsoncolor.Color(comma),
+		Colon:    jsoncolor.Color(colon),
+	}
+
+	v := []interface{}{
+		map[string]interface{}{"a": 1, "b": 2},
+	}
+
+	got := puncEncode(t, clrs, v)
+
+	key := func(s string) string { return "\"" + s + "\"" + reset }
+	val := func(s string) string { return s + reset }
+	want := brackets + "[" + reset + "\n  " +
+		braces + "{" + reset + "\n    " +
+		key("a") + colon + ":" + reset + " " + val("1") + comma + "," + reset + "\n    " +
+		key("b") + colon + ":" + reset + " " + val("2") + "\n  " +
+		braces + "}" + reset + "\n" +
+		brackets + "]" + reset + "\n"
+
+	require.Equal(t, want, got,
+		"each granular punctuation field should govern exactly its own class")
+}


### PR DESCRIPTION
Closes #16.

Adds individually-configurable color fields so punctuation classes can be styled separately, while keeping `Colors.Punc` as a fallback for backward compatibility.

## Changes
- New `Colors` fields: `Brackets` (`[` `]`), `Braces` (`{` `}`), `Comma` (`,`), `Colon` (`:`), all of type `Color`.
- Each field falls back to `Punc` when unset (zero value), so code that only sets `Punc` behaves exactly as before.
- The structural `"` is governed by `String`/`Key` (not `Punc`), so no quote field was added.

Default visual output is unchanged. Verified: `go build ./...`, `go test ./...`, and `golangci-lint run ./...` all clean.