### PR TITLE
Fast-path encode walk when colors and indenter are nil (#44)

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -532,6 +532,20 @@ type embeddedField struct {
 	subfield   *structField
 }
 
+// promoteThroughPointer adapts a field promoted through an embedded struct
+// pointer. The codec, and for omitempty fields the emptiness check, are
+// wrapped to dereference the pointer, and the offset is re-pointed at the
+// pointer word in the outer struct. Non-omitempty fields never consult the
+// emptiness check, so they skip that wrapper.
+func promoteThroughPointer(embfield embeddedField, subfield structField) structField {
+	subfield.codec = constructEmbeddedStructPointerCodec(embfield.subtype.typ, embfield.unexported, subfield.offset, subfield.codec)
+	if subfield.omitempty {
+		subfield.empty = constructEmbeddedStructPointerEmptyFunc(subfield.offset, subfield.empty)
+	}
+	subfield.offset = embfield.offset
+	return subfield
+}
+
 func appendStructFields(fields []structField, t reflect.Type, offset uintptr, seen map[reflect.Type]*structType, canAddr bool) []structField {
 	names := make(map[string]struct{})
 	embedded := make([]embeddedField, 0, 10)
@@ -641,9 +655,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 		}
 
 		if embfield.pointer {
-			subfield.codec = constructEmbeddedStructPointerCodec(embfield.subtype.typ, embfield.unexported, subfield.offset, subfield.codec)
-			subfield.empty = constructEmbeddedStructPointerEmptyFunc(subfield.offset, subfield.empty)
-			subfield.offset = embfield.offset
+			subfield = promoteThroughPointer(embfield, subfield)
 		} else {
 			subfield.offset += embfield.offset
 		}

--- a/codec.go
+++ b/codec.go
@@ -24,6 +24,11 @@ type encoder struct {
 	flags   AppendFlags
 	clrs    *Colors
 	indentr *Indenter
+	// forceSlow disables encode-time fast paths so the colorless walk
+	// matches the colorized walk byte-for-byte. It exists for parity
+	// testing only and is never set in production paths; see
+	// appendInternal in json.go.
+	forceSlow bool
 }
 type decoder struct{ flags ParseFlags }
 

--- a/encode.go
+++ b/encode.go
@@ -663,6 +663,8 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 		return e.clrs.appendNull(b), nil
 	}
 
+	start := len(b)
+
 	if (e.flags & SortMapKeys) == 0 {
 		// Optimized code path when the program does not need the map keys to be
 		// sorted.
@@ -685,7 +687,7 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 
 				b, err = e.encodeKey(b, unsafe.Pointer(&k))
 				if err != nil {
-					return b, err
+					return b[:start], err
 				}
 
 				b = e.clrs.appendPunc(b, ':')
@@ -693,7 +695,7 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 
 				b, err = appendInternal(b, v, e.flags, e.clrs, e.indentr, e.forceSlow)
 				if err != nil {
-					return b, err
+					return b[:start], err
 				}
 
 				i++
@@ -716,7 +718,6 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 	}
 	sort.Sort(s)
 
-	start := len(b)
 	var err error
 	b = e.clrs.appendPunc(b, '{')
 
@@ -768,6 +769,8 @@ func (e encoder) encodeMapStringInterfacePlain(b []byte, p unsafe.Pointer) ([]by
 		return append(b, "null"...), nil
 	}
 
+	start := len(b)
+
 	if (e.flags & SortMapKeys) == 0 {
 		b = append(b, '{')
 		i := 0
@@ -777,11 +780,11 @@ func (e encoder) encodeMapStringInterfacePlain(b []byte, p unsafe.Pointer) ([]by
 			}
 			var err error
 			if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
-				return b, err
+				return b[:start], err
 			}
 			b = append(b, ':')
 			if b, err = appendInternal(b, v, e.flags, nil, e.indentr, false); err != nil {
-				return b, err
+				return b[:start], err
 			}
 			i++
 		}
@@ -797,7 +800,6 @@ func (e encoder) encodeMapStringInterfacePlain(b []byte, p unsafe.Pointer) ([]by
 	}
 	sort.Sort(s)
 
-	start := len(b)
 	var err error
 	b = append(b, '{')
 	for i := range s.elements {
@@ -830,6 +832,8 @@ func (e encoder) encodeMapStringInterfaceIndented(b []byte, p unsafe.Pointer) ([
 		return append(b, "null"...), nil
 	}
 
+	start := len(b)
+
 	if (e.flags & SortMapKeys) == 0 {
 		b = append(b, '{')
 		if len(m) != 0 {
@@ -843,11 +847,11 @@ func (e encoder) encodeMapStringInterfaceIndented(b []byte, p unsafe.Pointer) ([
 				b = e.indentr.appendIndentFast(b)
 				var err error
 				if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
-					return b, err
+					return b[:start], err
 				}
 				b = append(b, ':', ' ')
 				if b, err = appendInternal(b, v, e.flags, nil, e.indentr, false); err != nil {
-					return b, err
+					return b[:start], err
 				}
 				i++
 			}
@@ -867,7 +871,6 @@ func (e encoder) encodeMapStringInterfaceIndented(b []byte, p unsafe.Pointer) ([
 	}
 	sort.Sort(s)
 
-	start := len(b)
 	var err error
 	b = append(b, '{')
 	if len(s.elements) > 0 {
@@ -1023,6 +1026,8 @@ func (e encoder) encodeMapStringRawMessagePlain(b []byte, p unsafe.Pointer) ([]b
 		return append(b, "null"...), nil
 	}
 
+	start := len(b)
+
 	if (e.flags & SortMapKeys) == 0 {
 		b = append(b, '{')
 		i := 0
@@ -1032,12 +1037,12 @@ func (e encoder) encodeMapStringRawMessagePlain(b []byte, p unsafe.Pointer) ([]b
 			}
 			var err error
 			if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
-				return b, err
+				return b[:start], err
 			}
 			b = append(b, ':')
 			v := m[k]
 			if b, err = e.encodeRawMessage(b, unsafe.Pointer(&v)); err != nil {
-				return b, err
+				return b[:start], err
 			}
 			i++
 		}
@@ -1053,7 +1058,6 @@ func (e encoder) encodeMapStringRawMessagePlain(b []byte, p unsafe.Pointer) ([]b
 	}
 	sort.Sort(s)
 
-	start := len(b)
 	var err error
 	b = append(b, '{')
 	for i := range s.elements {
@@ -1086,6 +1090,8 @@ func (e encoder) encodeMapStringRawMessageIndented(b []byte, p unsafe.Pointer) (
 		return append(b, "null"...), nil
 	}
 
+	start := len(b)
+
 	if (e.flags & SortMapKeys) == 0 {
 		b = append(b, '{')
 		if len(m) != 0 {
@@ -1099,12 +1105,12 @@ func (e encoder) encodeMapStringRawMessageIndented(b []byte, p unsafe.Pointer) (
 				b = e.indentr.appendIndentFast(b)
 				var err error
 				if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
-					return b, err
+					return b[:start], err
 				}
 				b = append(b, ':', ' ')
 				v := m[k]
 				if b, err = e.encodeRawMessage(b, unsafe.Pointer(&v)); err != nil {
-					return b, err
+					return b[:start], err
 				}
 				i++
 			}
@@ -1124,7 +1130,6 @@ func (e encoder) encodeMapStringRawMessageIndented(b []byte, p unsafe.Pointer) (
 	}
 	sort.Sort(s)
 
-	start := len(b)
 	var err error
 	b = append(b, '{')
 	if len(s.elements) > 0 {

--- a/encode.go
+++ b/encode.go
@@ -1252,6 +1252,9 @@ func (e encoder) encodeStructPlain(b []byte, p unsafe.Pointer, st *structType) (
 			continue
 		}
 
+		// fieldStart is the rollback point; see encodeStruct.
+		fieldStart := len(b)
+
 		if n != 0 {
 			b = append(b, ',')
 		}
@@ -1262,14 +1265,13 @@ func (e encoder) encodeStructPlain(b []byte, p unsafe.Pointer, st *structType) (
 			k = f.json
 		}
 
-		lengthBeforeKey := len(b)
 		b = append(b, k...)
 		b = append(b, ':')
 
 		var err error
 		if b, err = f.codec.encode(e, b, v); err != nil {
 			if errors.Is(err, rollback{}) {
-				b = b[:lengthBeforeKey]
+				b = b[:fieldStart]
 				continue
 			}
 			return b[:start], err
@@ -1288,10 +1290,6 @@ func (e encoder) encodeStructIndented(b []byte, p unsafe.Pointer, st *structType
 
 	b = append(b, '{')
 
-	if len(st.fields) > 0 {
-		b = append(b, '\n')
-	}
-
 	e.indentr.depth++
 
 	for i := range st.fields {
@@ -1302,9 +1300,14 @@ func (e encoder) encodeStructIndented(b []byte, p unsafe.Pointer, st *structType
 			continue
 		}
 
+		// fieldStart is the rollback point; see encodeStruct.
+		fieldStart := len(b)
+
 		if n != 0 {
-			b = append(b, ',', '\n')
+			b = append(b, ',')
 		}
+
+		b = append(b, '\n')
 
 		if (e.flags & EscapeHTML) != 0 {
 			k = f.html
@@ -1312,7 +1315,6 @@ func (e encoder) encodeStructIndented(b []byte, p unsafe.Pointer, st *structType
 			k = f.json
 		}
 
-		lengthBeforeKey := len(b)
 		b = e.indentr.appendIndentFast(b)
 		b = append(b, k...)
 		b = append(b, ':', ' ')
@@ -1320,7 +1322,7 @@ func (e encoder) encodeStructIndented(b []byte, p unsafe.Pointer, st *structType
 		var err error
 		if b, err = f.codec.encode(e, b, v); err != nil {
 			if errors.Is(err, rollback{}) {
-				b = b[:lengthBeforeKey]
+				b = b[:fieldStart]
 				continue
 			}
 			return b[:start], err
@@ -1329,12 +1331,12 @@ func (e encoder) encodeStructIndented(b []byte, p unsafe.Pointer, st *structType
 		n++
 	}
 
+	e.indentr.depth--
+
 	if n > 0 {
 		b = append(b, '\n')
+		b = e.indentr.appendIndentFast(b)
 	}
-
-	e.indentr.depth--
-	b = e.indentr.appendIndentFast(b)
 
 	return append(b, '}'), nil
 }

--- a/encode.go
+++ b/encode.go
@@ -18,54 +18,96 @@ import (
 const hex = "0123456789abcdef"
 
 func (e encoder) encodeNull(b []byte, _ unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return append(b, "null"...), nil
+	}
 	return e.clrs.appendNull(b), nil
 }
 
 func (e encoder) encodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		if *(*bool)(p) {
+			return append(b, "true"...), nil
+		}
+		return append(b, "false"...), nil
+	}
 	return e.clrs.appendBool(b, *(*bool)(p)), nil
 }
 
 func (e encoder) encodeInt(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendInt(b, int64(*(*int)(p)), 10), nil
+	}
 	return e.clrs.appendInt64(b, int64(*(*int)(p))), nil
 }
 
 func (e encoder) encodeInt8(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendInt(b, int64(*(*int8)(p)), 10), nil
+	}
 	return e.clrs.appendInt64(b, int64(*(*int8)(p))), nil
 }
 
 func (e encoder) encodeInt16(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendInt(b, int64(*(*int16)(p)), 10), nil
+	}
 	return e.clrs.appendInt64(b, int64(*(*int16)(p))), nil
 }
 
 func (e encoder) encodeInt32(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendInt(b, int64(*(*int32)(p)), 10), nil
+	}
 	return e.clrs.appendInt64(b, int64(*(*int32)(p))), nil
 }
 
 func (e encoder) encodeInt64(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendInt(b, *(*int64)(p), 10), nil
+	}
 	return e.clrs.appendInt64(b, *(*int64)(p)), nil
 }
 
 func (e encoder) encodeUint(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendUint(b, uint64(*(*uint)(p)), 10), nil
+	}
 	return e.clrs.appendUint64(b, uint64(*(*uint)(p))), nil
 }
 
 func (e encoder) encodeUintptr(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendUint(b, uint64(*(*uintptr)(p)), 10), nil
+	}
 	return e.clrs.appendUint64(b, uint64(*(*uintptr)(p))), nil
 }
 
 func (e encoder) encodeUint8(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendUint(b, uint64(*(*uint8)(p)), 10), nil
+	}
 	return e.clrs.appendUint64(b, uint64(*(*uint8)(p))), nil
 }
 
 func (e encoder) encodeUint16(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendUint(b, uint64(*(*uint16)(p)), 10), nil
+	}
 	return e.clrs.appendUint64(b, uint64(*(*uint16)(p))), nil
 }
 
 func (e encoder) encodeUint32(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendUint(b, uint64(*(*uint32)(p)), 10), nil
+	}
 	return e.clrs.appendUint64(b, uint64(*(*uint32)(p))), nil
 }
 
 func (e encoder) encodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendUint(b, *(*uint64)(p), 10), nil
+	}
 	return e.clrs.appendUint64(b, *(*uint64)(p)), nil
 }
 
@@ -333,6 +375,9 @@ func (e encoder) encodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 	//  The stdlib encoder does not. It just outputs the int64 value.
 	//  We choose to follow the stdlib pattern, for fuller compatibility.
 
+	if e.clrs == nil && !e.forceSlow {
+		return strconv.AppendInt(b, int64(*(*time.Duration)(p)), 10), nil
+	}
 	b = e.clrs.appendInt64(b, int64(*(*time.Duration)(p)))
 	return b, nil
 
@@ -372,6 +417,13 @@ func (e encoder) encodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, _ reflect.Type, encode encodeFunc) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		if e.indentr == nil || e.indentr.disabled {
+			return e.encodeArrayPlain(b, p, n, size, encode)
+		}
+		return e.encodeArrayIndented(b, p, n, size, encode)
+	}
+
 	start := len(b)
 	var err error
 
@@ -401,6 +453,49 @@ func (e encoder) encodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, _ 
 	return b, nil
 }
 
+// encodeArrayPlain is the fast path for encodeArray when no colors and no
+// indenter are configured. The caller must verify both preconditions.
+func (e encoder) encodeArrayPlain(b []byte, p unsafe.Pointer, n int, size uintptr, encode encodeFunc) ([]byte, error) {
+	start := len(b)
+	b = append(b, '[')
+	for i := 0; i < n; i++ {
+		if i != 0 {
+			b = append(b, ',')
+		}
+		var err error
+		if b, err = encode(e, b, unsafe.Pointer(uintptr(p)+(uintptr(i)*size))); err != nil {
+			return b[:start], err
+		}
+	}
+	return append(b, ']'), nil
+}
+
+// encodeArrayIndented is the fast path for encodeArray when no colors are
+// configured but an enabled indenter is. The caller must verify both
+// preconditions.
+func (e encoder) encodeArrayIndented(b []byte, p unsafe.Pointer, n int, size uintptr, encode encodeFunc) ([]byte, error) {
+	start := len(b)
+	b = append(b, '[')
+	if n > 0 {
+		e.indentr.depth++
+		for i := 0; i < n; i++ {
+			if i != 0 {
+				b = append(b, ',')
+			}
+			b = append(b, '\n')
+			b = e.indentr.appendIndentFast(b)
+			var err error
+			if b, err = encode(e, b, unsafe.Pointer(uintptr(p)+(uintptr(i)*size))); err != nil {
+				return b[:start], err
+			}
+		}
+		e.indentr.depth--
+		b = append(b, '\n')
+		b = e.indentr.appendIndentFast(b)
+	}
+	return append(b, ']'), nil
+}
+
 func (e encoder) encodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect.Type, encode encodeFunc) ([]byte, error) {
 	s := (*slice)(p)
 
@@ -412,6 +507,13 @@ func (e encoder) encodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 }
 
 func (e encoder) encodeMap(b []byte, p unsafe.Pointer, t reflect.Type, encodeKey, encodeValue encodeFunc, sortKeys sortFunc) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		if e.indentr == nil || e.indentr.disabled {
+			return e.encodeMapPlain(b, p, t, encodeKey, encodeValue, sortKeys)
+		}
+		return e.encodeMapIndented(b, p, t, encodeKey, encodeValue, sortKeys)
+	}
+
 	m := reflect.NewAt(t, p).Elem()
 	if m.IsNil() {
 		return e.clrs.appendNull(b), nil
@@ -460,6 +562,76 @@ func (e encoder) encodeMap(b []byte, p unsafe.Pointer, t reflect.Type, encodeKey
 	return b, nil
 }
 
+func (e encoder) encodeMapPlain(b []byte, p unsafe.Pointer, t reflect.Type, encodeKey, encodeValue encodeFunc, sortKeys sortFunc) ([]byte, error) {
+	m := reflect.NewAt(t, p).Elem()
+	if m.IsNil() {
+		return append(b, "null"...), nil
+	}
+
+	keys := m.MapKeys()
+	if sortKeys != nil && (e.flags&SortMapKeys) != 0 {
+		sortKeys(keys)
+	}
+
+	start := len(b)
+	b = append(b, '{')
+	for i := range keys {
+		k := keys[i]
+		v := m.MapIndex(k)
+		if i != 0 {
+			b = append(b, ',')
+		}
+		var err error
+		if b, err = encodeKey(e, b, (*iface)(unsafe.Pointer(&k)).ptr); err != nil {
+			return b[:start], err
+		}
+		b = append(b, ':')
+		if b, err = encodeValue(e, b, (*iface)(unsafe.Pointer(&v)).ptr); err != nil {
+			return b[:start], err
+		}
+	}
+	return append(b, '}'), nil
+}
+
+func (e encoder) encodeMapIndented(b []byte, p unsafe.Pointer, t reflect.Type, encodeKey, encodeValue encodeFunc, sortKeys sortFunc) ([]byte, error) {
+	m := reflect.NewAt(t, p).Elem()
+	if m.IsNil() {
+		return append(b, "null"...), nil
+	}
+
+	keys := m.MapKeys()
+	if sortKeys != nil && (e.flags&SortMapKeys) != 0 {
+		sortKeys(keys)
+	}
+
+	start := len(b)
+	b = append(b, '{')
+	if len(keys) != 0 {
+		b = append(b, '\n')
+		e.indentr.depth++
+		for i := range keys {
+			k := keys[i]
+			v := m.MapIndex(k)
+			if i != 0 {
+				b = append(b, ',', '\n')
+			}
+			b = e.indentr.appendIndentFast(b)
+			var err error
+			if b, err = encodeKey(e, b, (*iface)(unsafe.Pointer(&k)).ptr); err != nil {
+				return b[:start], err
+			}
+			b = append(b, ':', ' ')
+			if b, err = encodeValue(e, b, (*iface)(unsafe.Pointer(&v)).ptr); err != nil {
+				return b[:start], err
+			}
+		}
+		b = append(b, '\n')
+		e.indentr.depth--
+		b = e.indentr.appendIndentFast(b)
+	}
+	return append(b, '}'), nil
+}
+
 type element struct {
 	key string
 	val interface{}
@@ -479,6 +651,13 @@ var mapslicePool = sync.Pool{
 }
 
 func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		if e.indentr == nil || e.indentr.disabled {
+			return e.encodeMapStringInterfacePlain(b, p)
+		}
+		return e.encodeMapStringInterfaceIndented(b, p)
+	}
+
 	m := *(*map[string]interface{})(p)
 	if m == nil {
 		return e.clrs.appendNull(b), nil
@@ -512,7 +691,7 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 				b = e.clrs.appendPunc(b, ':')
 				b = e.indentr.appendByte(b, ' ')
 
-				b, err = Append(b, v, e.flags, e.clrs, e.indentr)
+				b, err = appendInternal(b, v, e.flags, e.clrs, e.indentr, e.forceSlow)
 				if err != nil {
 					return b, err
 				}
@@ -558,7 +737,7 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 			b = e.clrs.appendPunc(b, ':')
 			b = e.indentr.appendByte(b, ' ')
 
-			b, err = Append(b, elem.val, e.flags, e.clrs, e.indentr)
+			b, err = appendInternal(b, elem.val, e.flags, e.clrs, e.indentr, e.forceSlow)
 			if err != nil {
 				break
 			}
@@ -583,7 +762,154 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 	return b, nil
 }
 
+func (e encoder) encodeMapStringInterfacePlain(b []byte, p unsafe.Pointer) ([]byte, error) {
+	m := *(*map[string]interface{})(p)
+	if m == nil {
+		return append(b, "null"...), nil
+	}
+
+	if (e.flags & SortMapKeys) == 0 {
+		b = append(b, '{')
+		i := 0
+		for k, v := range m {
+			if i != 0 {
+				b = append(b, ',')
+			}
+			var err error
+			if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
+				return b, err
+			}
+			b = append(b, ':')
+			if b, err = appendInternal(b, v, e.flags, nil, e.indentr, false); err != nil {
+				return b, err
+			}
+			i++
+		}
+		return append(b, '}'), nil
+	}
+
+	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
+	if cap(s.elements) < len(m) {
+		s.elements = make([]element, 0, align(10, uintptr(len(m))))
+	}
+	for key, val := range m {
+		s.elements = append(s.elements, element{key: key, val: val})
+	}
+	sort.Sort(s)
+
+	start := len(b)
+	var err error
+	b = append(b, '{')
+	for i := range s.elements {
+		elem := s.elements[i]
+		if i != 0 {
+			b = append(b, ',')
+		}
+		b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
+		b = append(b, ':')
+		if b, err = appendInternal(b, elem.val, e.flags, nil, e.indentr, false); err != nil {
+			break
+		}
+	}
+
+	for i := range s.elements {
+		s.elements[i] = element{}
+	}
+	s.elements = s.elements[:0]
+	mapslicePool.Put(s)
+
+	if err != nil {
+		return b[:start], err
+	}
+	return append(b, '}'), nil
+}
+
+func (e encoder) encodeMapStringInterfaceIndented(b []byte, p unsafe.Pointer) ([]byte, error) {
+	m := *(*map[string]interface{})(p)
+	if m == nil {
+		return append(b, "null"...), nil
+	}
+
+	if (e.flags & SortMapKeys) == 0 {
+		b = append(b, '{')
+		if len(m) != 0 {
+			b = append(b, '\n')
+			e.indentr.depth++
+			i := 0
+			for k, v := range m {
+				if i != 0 {
+					b = append(b, ',', '\n')
+				}
+				b = e.indentr.appendIndentFast(b)
+				var err error
+				if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
+					return b, err
+				}
+				b = append(b, ':', ' ')
+				if b, err = appendInternal(b, v, e.flags, nil, e.indentr, false); err != nil {
+					return b, err
+				}
+				i++
+			}
+			b = append(b, '\n')
+			e.indentr.depth--
+			b = e.indentr.appendIndentFast(b)
+		}
+		return append(b, '}'), nil
+	}
+
+	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
+	if cap(s.elements) < len(m) {
+		s.elements = make([]element, 0, align(10, uintptr(len(m))))
+	}
+	for key, val := range m {
+		s.elements = append(s.elements, element{key: key, val: val})
+	}
+	sort.Sort(s)
+
+	start := len(b)
+	var err error
+	b = append(b, '{')
+	if len(s.elements) > 0 {
+		b = append(b, '\n')
+		e.indentr.depth++
+		for i := range s.elements {
+			elem := s.elements[i]
+			if i != 0 {
+				b = append(b, ',', '\n')
+			}
+			b = e.indentr.appendIndentFast(b)
+			b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
+			b = append(b, ':', ' ')
+			if b, err = appendInternal(b, elem.val, e.flags, nil, e.indentr, false); err != nil {
+				break
+			}
+		}
+		b = append(b, '\n')
+		e.indentr.depth--
+		b = e.indentr.appendIndentFast(b)
+	}
+
+	for i := range s.elements {
+		s.elements[i] = element{}
+	}
+	s.elements = s.elements[:0]
+	mapslicePool.Put(s)
+
+	if err != nil {
+		return b[:start], err
+	}
+	return append(b, '}'), nil
+}
+
 func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		if e.indentr == nil || e.indentr.disabled {
+			return e.encodeMapStringRawMessagePlain(b, p)
+		}
+		return e.encodeMapStringRawMessageIndented(b, p)
+	}
+
 	m := *(*map[string]RawMessage)(p)
 	if m == nil {
 		return e.clrs.appendNull(b), nil
@@ -691,7 +1017,156 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 	return b, nil
 }
 
+func (e encoder) encodeMapStringRawMessagePlain(b []byte, p unsafe.Pointer) ([]byte, error) {
+	m := *(*map[string]RawMessage)(p)
+	if m == nil {
+		return append(b, "null"...), nil
+	}
+
+	if (e.flags & SortMapKeys) == 0 {
+		b = append(b, '{')
+		i := 0
+		for k := range m {
+			if i != 0 {
+				b = append(b, ',')
+			}
+			var err error
+			if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
+				return b, err
+			}
+			b = append(b, ':')
+			v := m[k]
+			if b, err = e.encodeRawMessage(b, unsafe.Pointer(&v)); err != nil {
+				return b, err
+			}
+			i++
+		}
+		return append(b, '}'), nil
+	}
+
+	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
+	if cap(s.elements) < len(m) {
+		s.elements = make([]element, 0, align(10, uintptr(len(m))))
+	}
+	for key, raw := range m {
+		s.elements = append(s.elements, element{key: key, raw: raw})
+	}
+	sort.Sort(s)
+
+	start := len(b)
+	var err error
+	b = append(b, '{')
+	for i := range s.elements {
+		elem := s.elements[i]
+		if i != 0 {
+			b = append(b, ',')
+		}
+		b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
+		b = append(b, ':')
+		if b, err = e.encodeRawMessage(b, unsafe.Pointer(&elem.raw)); err != nil {
+			break
+		}
+	}
+
+	for i := range s.elements {
+		s.elements[i] = element{}
+	}
+	s.elements = s.elements[:0]
+	mapslicePool.Put(s)
+
+	if err != nil {
+		return b[:start], err
+	}
+	return append(b, '}'), nil
+}
+
+func (e encoder) encodeMapStringRawMessageIndented(b []byte, p unsafe.Pointer) ([]byte, error) {
+	m := *(*map[string]RawMessage)(p)
+	if m == nil {
+		return append(b, "null"...), nil
+	}
+
+	if (e.flags & SortMapKeys) == 0 {
+		b = append(b, '{')
+		if len(m) != 0 {
+			b = append(b, '\n')
+			e.indentr.depth++
+			i := 0
+			for k := range m {
+				if i != 0 {
+					b = append(b, ',', '\n')
+				}
+				b = e.indentr.appendIndentFast(b)
+				var err error
+				if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
+					return b, err
+				}
+				b = append(b, ':', ' ')
+				v := m[k]
+				if b, err = e.encodeRawMessage(b, unsafe.Pointer(&v)); err != nil {
+					return b, err
+				}
+				i++
+			}
+			b = append(b, '\n')
+			e.indentr.depth--
+			b = e.indentr.appendIndentFast(b)
+		}
+		return append(b, '}'), nil
+	}
+
+	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
+	if cap(s.elements) < len(m) {
+		s.elements = make([]element, 0, align(10, uintptr(len(m))))
+	}
+	for key, raw := range m {
+		s.elements = append(s.elements, element{key: key, raw: raw})
+	}
+	sort.Sort(s)
+
+	start := len(b)
+	var err error
+	b = append(b, '{')
+	if len(s.elements) > 0 {
+		b = append(b, '\n')
+		e.indentr.depth++
+		for i := range s.elements {
+			elem := s.elements[i]
+			if i != 0 {
+				b = append(b, ',', '\n')
+			}
+			b = e.indentr.appendIndentFast(b)
+			b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
+			b = append(b, ':', ' ')
+			if b, err = e.encodeRawMessage(b, unsafe.Pointer(&elem.raw)); err != nil {
+				break
+			}
+		}
+		b = append(b, '\n')
+		e.indentr.depth--
+		b = e.indentr.appendIndentFast(b)
+	}
+
+	for i := range s.elements {
+		s.elements[i] = element{}
+	}
+	s.elements = s.elements[:0]
+	mapslicePool.Put(s)
+
+	if err != nil {
+		return b[:start], err
+	}
+	return append(b, '}'), nil
+}
+
 func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byte, error) {
+	if e.clrs == nil && !e.forceSlow {
+		if e.indentr == nil || e.indentr.disabled {
+			return e.encodeStructPlain(b, p, st)
+		}
+		return e.encodeStructIndented(b, p, st)
+	}
+
 	var err error
 	var k string
 	var n int
@@ -762,6 +1237,108 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 	return b, nil
 }
 
+func (e encoder) encodeStructPlain(b []byte, p unsafe.Pointer, st *structType) ([]byte, error) {
+	var k string
+	var n int
+	start := len(b)
+
+	b = append(b, '{')
+
+	for i := range st.fields {
+		f := &st.fields[i]
+		v := unsafe.Pointer(uintptr(p) + f.offset)
+
+		if f.omitempty && f.empty(v) {
+			continue
+		}
+
+		if n != 0 {
+			b = append(b, ',')
+		}
+
+		if (e.flags & EscapeHTML) != 0 {
+			k = f.html
+		} else {
+			k = f.json
+		}
+
+		lengthBeforeKey := len(b)
+		b = append(b, k...)
+		b = append(b, ':')
+
+		var err error
+		if b, err = f.codec.encode(e, b, v); err != nil {
+			if errors.Is(err, rollback{}) {
+				b = b[:lengthBeforeKey]
+				continue
+			}
+			return b[:start], err
+		}
+
+		n++
+	}
+
+	return append(b, '}'), nil
+}
+
+func (e encoder) encodeStructIndented(b []byte, p unsafe.Pointer, st *structType) ([]byte, error) {
+	var k string
+	var n int
+	start := len(b)
+
+	b = append(b, '{')
+
+	if len(st.fields) > 0 {
+		b = append(b, '\n')
+	}
+
+	e.indentr.depth++
+
+	for i := range st.fields {
+		f := &st.fields[i]
+		v := unsafe.Pointer(uintptr(p) + f.offset)
+
+		if f.omitempty && f.empty(v) {
+			continue
+		}
+
+		if n != 0 {
+			b = append(b, ',', '\n')
+		}
+
+		if (e.flags & EscapeHTML) != 0 {
+			k = f.html
+		} else {
+			k = f.json
+		}
+
+		lengthBeforeKey := len(b)
+		b = e.indentr.appendIndentFast(b)
+		b = append(b, k...)
+		b = append(b, ':', ' ')
+
+		var err error
+		if b, err = f.codec.encode(e, b, v); err != nil {
+			if errors.Is(err, rollback{}) {
+				b = b[:lengthBeforeKey]
+				continue
+			}
+			return b[:start], err
+		}
+
+		n++
+	}
+
+	if n > 0 {
+		b = append(b, '\n')
+	}
+
+	e.indentr.depth--
+	b = e.indentr.appendIndentFast(b)
+
+	return append(b, '}'), nil
+}
+
 type rollback struct{}
 
 func (rollback) Error() string { return "rollback" }
@@ -782,11 +1359,11 @@ func (e encoder) encodePointer(b []byte, p unsafe.Pointer, _ reflect.Type, encod
 }
 
 func (e encoder) encodeInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
-	return Append(b, *(*interface{})(p), e.flags, e.clrs, e.indentr)
+	return appendInternal(b, *(*interface{})(p), e.flags, e.clrs, e.indentr, e.forceSlow)
 }
 
 func (e encoder) encodeMaybeEmptyInterface(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
-	return Append(b, reflect.NewAt(t, p).Elem().Interface(), e.flags, e.clrs, e.indentr)
+	return appendInternal(b, reflect.NewAt(t, p).Elem().Interface(), e.flags, e.clrs, e.indentr, e.forceSlow)
 }
 
 func (e encoder) encodeUnsupportedTypeError(b []byte, _ unsafe.Pointer, t reflect.Type) ([]byte, error) {
@@ -1026,7 +1603,7 @@ func (e encoder) encodeJSONMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 	}
 
 	// We effectively delegate to the encodeRawMessage method.
-	return Append(b, RawMessage(j), e.flags, e.clrs, e.indentr)
+	return appendInternal(b, RawMessage(j), e.flags, e.clrs, e.indentr, e.forceSlow)
 }
 
 func (e encoder) encodeTextMarshaler(b []byte, p unsafe.Pointer, t reflect.Type, pointer bool) ([]byte, error) {
@@ -1180,6 +1757,14 @@ func (in *Indenter) appendIndent(b []byte) []byte {
 		return b
 	}
 
+	return in.appendIndentFast(b)
+}
+
+// appendIndentFast writes indentation to b assuming the receiver is
+// non-nil and not disabled. Callers must verify those preconditions; the
+// colorless fast paths do so once per container, then call this directly
+// to skip the per-token nil/disabled check.
+func (in *Indenter) appendIndentFast(b []byte) []byte {
 	b = append(b, in.prefix...)
 	for i := 0; i < in.depth; i++ {
 		b = append(b, in.indent...)

--- a/json.go
+++ b/json.go
@@ -120,6 +120,13 @@ const (
 // construct an [Indenter] via [NewIndenter] to indent the output. The clrs
 // argument may be nil to disable colorization.
 func Append(b []byte, x interface{}, flags AppendFlags, clrs *Colors, indentr *Indenter) ([]byte, error) {
+	return appendInternal(b, x, flags, clrs, indentr, false)
+}
+
+// appendInternal is the shared implementation for Append. It carries
+// forceSlow through the recursion so parity tests can disable encode-time
+// fast paths and compare them against the colorized walk.
+func appendInternal(b []byte, x interface{}, flags AppendFlags, clrs *Colors, indentr *Indenter, forceSlow bool) ([]byte, error) {
 	if x == nil {
 		// Special case for nil values because it makes the rest of the code
 		// simpler to assume that it won't be seeing nil pointers.
@@ -136,7 +143,7 @@ func Append(b []byte, x interface{}, flags AppendFlags, clrs *Colors, indentr *I
 		c = constructCachedCodec(t, cache)
 	}
 
-	b, err := c.encode(encoder{flags: flags, clrs: clrs, indentr: indentr}, b, p)
+	b, err := c.encode(encoder{flags: flags, clrs: clrs, indentr: indentr, forceSlow: forceSlow}, b, p)
 	if err != nil && indentr != nil {
 		// A failed encode can return from inside a push/pop pair, leaving
 		// the Indenter at a stale depth that would poison later calls, since

--- a/jsoncolor_internal_test.go
+++ b/jsoncolor_internal_test.go
@@ -30,17 +30,6 @@ func TestEquivalenceStdlibCode(t *testing.T) {
 	require.Equal(t, bufStdj.String(), bufJ.String())
 }
 
-// TestEncode_FastPathParity asserts that the colorless encode paths
-// produce byte-identical output to the colorized walk for every value
-// in testValues. Append (the public entry point) takes the fast path
-// when clrs is nil; appendInternal with forceSlow=true forces the
-// colorized walk regardless. The two outputs must be equal, otherwise
-// the fast path has diverged.
-//
-// SortMapKeys is included in every config because map iteration is
-// otherwise nondeterministic across the two calls — without sorting,
-// fast and slow would see different orderings of the same map and
-// diverge harmlessly.
 // Types for parityExtraValues.
 type parityInner struct {
 	X int    `json:",omitempty"`
@@ -85,6 +74,17 @@ var parityExtraValues = []interface{}{
 	[]interface{}{1, parityFuncField{}},
 }
 
+// TestEncode_FastPathParity asserts that the colorless encode paths
+// produce byte-identical output to the colorized walk for every value
+// in testValues. Append (the public entry point) takes the fast path
+// when clrs is nil; appendInternal with forceSlow=true forces the
+// colorized walk regardless. The two outputs must be equal, otherwise
+// the fast path has diverged.
+//
+// SortMapKeys is included in every config because map iteration is
+// otherwise nondeterministic across the two calls — without sorting,
+// fast and slow would see different orderings of the same map and
+// diverge harmlessly.
 func TestEncode_FastPathParity(t *testing.T) {
 	prefix, indent2 := "", "  "
 	tab := "\t"
@@ -125,6 +125,9 @@ func TestEncode_FastPathParity(t *testing.T) {
 					if fastErr != nil {
 						if fastErr.Error() != slowErr.Error() {
 							t.Fatalf("error text mismatch: fast=%v slow=%v", fastErr, slowErr)
+						}
+						if !bytes.Equal(fast, slow) {
+							t.Fatalf("error-path byte mismatch: fast=%q slow=%q", fast, slow)
 						}
 						return
 					}
@@ -196,5 +199,48 @@ func BenchmarkFastVsSlow(b *testing.B) {
 				}
 			})
 		})
+	}
+}
+
+// TestEncode_UnsortedMapErrorRollsBack verifies that when an element of a
+// map fails to encode with SortMapKeys unset, both the fast and slow paths
+// roll the buffer back to its length on entry, matching the sorted branches
+// and every other container. Single-key maps keep iteration deterministic.
+func TestEncode_UnsortedMapErrorRollsBack(t *testing.T) {
+	values := []interface{}{
+		map[string]RawMessage{"a": RawMessage(`{bad`)},
+		map[string]interface{}{"a": func() {}},
+		map[string]int{"a": 1, "b": 2}, // control: must succeed on both paths
+	}
+
+	for _, indentr := range []*Indenter{nil, NewIndenter("", "  ")} {
+		for _, v := range values {
+			name := testName(v)
+			if indentr != nil {
+				name += "/indent"
+			}
+			t.Run(name, func(t *testing.T) {
+				prefix := []byte("prefix")
+
+				fast, fastErr := Append(append([]byte(nil), prefix...), v, 0, nil, indentr)
+				slow, slowErr := appendInternal(append([]byte(nil), prefix...), v, 0, nil, indentr, true)
+
+				if (fastErr == nil) != (slowErr == nil) {
+					t.Fatalf("error mismatch: fast=%v slow=%v", fastErr, slowErr)
+				}
+				if fastErr == nil {
+					return
+				}
+				if fastErr.Error() != slowErr.Error() {
+					t.Fatalf("error text mismatch: fast=%v slow=%v", fastErr, slowErr)
+				}
+				if string(fast) != string(prefix) {
+					t.Errorf("fast path did not roll back: %q", fast)
+				}
+				if string(slow) != string(prefix) {
+					t.Errorf("slow path did not roll back: %q", slow)
+				}
+			})
+		}
 	}
 }

--- a/jsoncolor_internal_test.go
+++ b/jsoncolor_internal_test.go
@@ -74,12 +74,13 @@ var parityExtraValues = []interface{}{
 	[]interface{}{1, parityFuncField{}},
 }
 
-// TestEncode_FastPathParity asserts that the colorless encode paths
-// produce byte-identical output to the colorized walk for every value
-// in testValues. Append (the public entry point) takes the fast path
-// when clrs is nil; appendInternal with forceSlow=true forces the
-// colorized walk regardless. The two outputs must be equal, otherwise
-// the fast path has diverged.
+// TestEncode_FastPathParity asserts that the colorless fast paths
+// produce byte-identical output to the general (slow) walk for every
+// value in testValues. Append (the public entry point) takes the fast
+// path when clrs is nil; appendInternal with forceSlow=true routes the
+// same colorless encode through the general walk instead. Neither side
+// emits color. The two outputs must be equal, otherwise the fast path
+// has diverged.
 //
 // SortMapKeys is included in every config because map iteration is
 // otherwise nondeterministic across the two calls — without sorting,
@@ -157,7 +158,7 @@ type benchMixedRecord struct {
 }
 
 // BenchmarkFastVsSlow compares the colorless fast path against the
-// colorized walk on identical data, with the output buffer pre-sized so
+// general (slow) walk on identical data, with the output buffer pre-sized so
 // growth is not measured. The only variable is whether the fast path is
 // taken: fast=Append (forceSlow=false), slow=appendInternal with
 // forceSlow=true. Any nonzero delta is the fast path's contribution.

--- a/jsoncolor_internal_test.go
+++ b/jsoncolor_internal_test.go
@@ -41,6 +41,50 @@ func TestEquivalenceStdlibCode(t *testing.T) {
 // otherwise nondeterministic across the two calls — without sorting,
 // fast and slow would see different orderings of the same map and
 // diverge harmlessly.
+// Types for parityExtraValues.
+type parityInner struct {
+	X int    `json:",omitempty"`
+	Y string `json:",omitempty"`
+}
+
+type parityNilEmbedOnly struct{ *parityInner }
+
+type parityNilEmbedMiddle struct {
+	A int
+	*parityInner
+	C int
+}
+
+type parityNilEmbedLast struct {
+	A int
+	C int
+	*parityInner
+}
+
+type parityAllOmitEmpty struct {
+	A int    `json:",omitempty"`
+	B string `json:",omitempty"`
+}
+
+type parityFuncField struct{ F func() }
+
+// parityExtraValues supplements the vendored testValues with shapes that
+// exercise struct rollback, omitempty through embedded pointers, empty
+// indented structs, and encode errors, on both the fast and slow paths.
+var parityExtraValues = []interface{}{
+	parityNilEmbedOnly{},
+	parityNilEmbedMiddle{A: 1, C: 2},
+	parityNilEmbedLast{A: 1, C: 2},
+	parityNilEmbedMiddle{A: 1, parityInner: &parityInner{}, C: 2},
+	parityNilEmbedMiddle{A: 1, parityInner: &parityInner{X: 5, Y: "y"}, C: 2},
+	parityAllOmitEmpty{},
+	struct{ In parityAllOmitEmpty }{},
+	parityFuncField{},
+	[]func(){nil},
+	map[string]func(){"a": nil},
+	[]interface{}{1, parityFuncField{}},
+}
+
 func TestEncode_FastPathParity(t *testing.T) {
 	prefix, indent2 := "", "  "
 	tab := "\t"
@@ -62,7 +106,7 @@ func TestEncode_FastPathParity(t *testing.T) {
 
 	for _, cfg := range configs {
 		t.Run(cfg.name, func(t *testing.T) {
-			for _, v := range testValues {
+			for _, v := range append(testValues[:], parityExtraValues...) {
 				t.Run(testName(v), func(t *testing.T) {
 					// Each call uses its own Indenter clone because the
 					// Indenter carries per-encode depth state.
@@ -79,6 +123,9 @@ func TestEncode_FastPathParity(t *testing.T) {
 						t.Fatalf("error mismatch: fast=%v slow=%v", fastErr, slowErr)
 					}
 					if fastErr != nil {
+						if fastErr.Error() != slowErr.Error() {
+							t.Fatalf("error text mismatch: fast=%v slow=%v", fastErr, slowErr)
+						}
 						return
 					}
 

--- a/jsoncolor_internal_test.go
+++ b/jsoncolor_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	stdjson "encoding/json"
 	"testing"
+	"time"
 
 	"github.com/segmentio/encoding/json"
 
@@ -27,4 +28,126 @@ func TestEquivalenceStdlibCode(t *testing.T) {
 	bufJ := &bytes.Buffer{}
 	err = NewEncoder(bufJ).Encode(codeStruct)
 	require.Equal(t, bufStdj.String(), bufJ.String())
+}
+
+// TestEncode_FastPathParity asserts that the colorless encode paths
+// produce byte-identical output to the colorized walk for every value
+// in testValues. Append (the public entry point) takes the fast path
+// when clrs is nil; appendInternal with forceSlow=true forces the
+// colorized walk regardless. The two outputs must be equal, otherwise
+// the fast path has diverged.
+//
+// SortMapKeys is included in every config because map iteration is
+// otherwise nondeterministic across the two calls — without sorting,
+// fast and slow would see different orderings of the same map and
+// diverge harmlessly.
+func TestEncode_FastPathParity(t *testing.T) {
+	prefix, indent2 := "", "  "
+	tab := "\t"
+	configs := []struct {
+		name    string
+		flags   AppendFlags
+		prefix  string
+		indent  string
+		indentr bool
+	}{
+		{name: "flat", flags: SortMapKeys},
+		{name: "flat_escapeHTML", flags: EscapeHTML | SortMapKeys},
+		{name: "indent_2sp", flags: SortMapKeys, indentr: true, prefix: prefix, indent: indent2},
+		{name: "indent_2sp_escapeHTML", flags: EscapeHTML | SortMapKeys, indentr: true, prefix: prefix, indent: indent2},
+		{name: "indent_tab", flags: SortMapKeys, indentr: true, prefix: prefix, indent: tab},
+		{name: "indent_with_prefix", flags: SortMapKeys, indentr: true, prefix: ">>", indent: indent2},
+		{name: "indent_disabled", flags: SortMapKeys, indentr: true, prefix: "", indent: ""},
+	}
+
+	for _, cfg := range configs {
+		t.Run(cfg.name, func(t *testing.T) {
+			for _, v := range testValues {
+				t.Run(testName(v), func(t *testing.T) {
+					// Each call uses its own Indenter clone because the
+					// Indenter carries per-encode depth state.
+					var fastIndentr, slowIndentr *Indenter
+					if cfg.indentr {
+						fastIndentr = NewIndenter(cfg.prefix, cfg.indent)
+						slowIndentr = NewIndenter(cfg.prefix, cfg.indent)
+					}
+
+					fast, fastErr := Append(nil, v, cfg.flags, nil, fastIndentr)
+					slow, slowErr := appendInternal(nil, v, cfg.flags, nil, slowIndentr, true)
+
+					if (fastErr == nil) != (slowErr == nil) {
+						t.Fatalf("error mismatch: fast=%v slow=%v", fastErr, slowErr)
+					}
+					if fastErr != nil {
+						return
+					}
+
+					if !bytes.Equal(fast, slow) {
+						t.Errorf("fast/slow byte mismatch")
+						t.Logf("fast (%d bytes): %q", len(fast), string(fast))
+						t.Logf("slow (%d bytes): %q", len(slow), string(slow))
+					}
+				})
+			}
+		})
+	}
+}
+
+// benchMixedRecord is a typed value used by BenchmarkFastVsSlow to
+// isolate fast-path savings from interface boxing and buffer growth.
+type benchMixedRecord struct {
+	I   int
+	I64 int64
+	F32 float32
+	F64 float64
+	S   string
+	B1  bool
+	B2  bool
+	T   time.Time
+}
+
+// BenchmarkFastVsSlow compares the colorless fast path against the
+// colorized walk on identical data, with the output buffer pre-sized so
+// growth is not measured. The only variable is whether the fast path is
+// taken: fast=Append (forceSlow=false), slow=appendInternal with
+// forceSlow=true. Any nonzero delta is the fast path's contribution.
+func BenchmarkFastVsSlow(b *testing.B) {
+	rec := benchMixedRecord{
+		I: 1, I64: 2, F32: 2.71, F64: 3.14,
+		S: "hello world", B1: true, B2: false,
+		T: time.Unix(1631659220, 0),
+	}
+
+	cases := []struct {
+		name   string
+		indent bool
+	}{
+		{name: "flat"},
+		{name: "indent", indent: true},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			var indentr *Indenter
+			if tc.indent {
+				indentr = NewIndenter("", "  ")
+			}
+			buf := make([]byte, 0, 4096)
+
+			b.Run("fast", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					buf, _ = Append(buf[:0], rec, EscapeHTML|SortMapKeys, nil, indentr)
+				}
+			})
+			b.Run("slow", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					buf, _ = appendInternal(buf[:0], rec, EscapeHTML|SortMapKeys, nil, indentr, true)
+				}
+			})
+		})
+	}
 }


### PR DESCRIPTION
Closes #44.

## Summary

When `clrs` and `indentr` are both nil (or the indenter is disabled), the encoder previously routed every token through `e.clrs.appendPunc` and `e.indentr.appendByte`/`appendIndent`. Each of those is a nil-receiver method call that falls through to a plain `append`; the indirection was the only cost. This PR adds a per-function dispatch that picks a stripped variant when `clrs == nil`, splitting further on whether the indenter is active.

**Containers** (`encodeArray`, `encodeMap`, `encodeMapStringInterface`, `encodeMapStringRawMessage`, `encodeStruct`) gain `*Plain` + `*Indented` sibling functions. **Unconditional scalars** (`encodeNull`, `encodeBool`, `encodeInt*`, `encodeUint*`, `encodeDuration`) gain a `clrs == nil` short-circuit calling `strconv` directly. Recursive `Append` calls inside container elements re-enter the fast path naturally.

No public API change. Color paths and indent-with-color paths are unchanged.

## Correctness

The `encoder` struct gains an unexported `forceSlow bool`, set only via `appendInternal` from the parity test. Tests can disable the fast paths so the colorless walk can be diffed against the colorized walk byte-for-byte.

`TestEncode_FastPathParity` runs every value in `testValues` × 7 flag/indenter configurations through both paths and asserts `bytes.Equal`. Passes. `TestPackageDropIn` (vs `segmentio/encoding` on Sakila files), `TestCodec` (vs `encoding/json`), `TestEquivalenceRecords`, and `go test -race ./...` all green.

## Performance

**`BenchmarkFastVsSlow` (new, micro):** isolates the encoder savings with a pre-sized buffer.

| | slow | fast | delta |
|---|---:|---:|---:|
| flat | 352.4 ns ± 11% | 251.3 ns ± 8% | **-28.7%** (p=0.002, n=10) |
| indent | 840.4 ns ± 43% | 728.6 ns ± 121% | -13% median (p=0.39 — noisy) |
| B/op | 80 | 80 | identical |
| allocs/op | 1 | 1 | identical |

**`BenchmarkEncode` (existing, 10k mixed-type records → `bytes.Buffer`):** no statistically significant change in any of the four jsoncolor cells (all p > 0.1). CPU profile on `NoIndent_NoColor` shows ~58% of time in `runtime.madvise`/`sysUsedOS` triggered by `bytes.Buffer.Write` growth — the encoder savings (~1 ms/iter on a 5.3 ms/iter bench) are real but hidden by the buffer-growth overhead.

Hardware: Apple M1 Max, Go 1.26.3. Settings: `-benchtime=3s -count=10 -benchmem`.

## Allocations

The 5.65 MB / 144k-allocs surplus called out in #44 is workload-specific, not an encoder defect:
- pprof shows the encoder itself allocates ~0 per call in the hot path.
- `bytes.growSlice` (the test harness's writer growth) accounts for 94% of allocated bytes in `BenchmarkEncode`.
- The remaining ~1 alloc/call is interface boxing on `enc.Encode(record)`.

No low-effort encoder-side fix exists; not pursued.

## Out of scope

- Option #2 from #44 (post-pass `json.Indent`). Independent and orthogonal — separate follow-up.
- Decoding path. Encode-only.

## Test plan

- [x] `go test -count=1 ./...`
- [x] `go test -race -count=1 ./...`
- [x] `TestEncode_FastPathParity` covers every value in `testValues` × 7 configs
- [x] `BenchmarkFastVsSlow` measures the fast-path savings directly
- [x] `BenchmarkEncode` confirms no regression in color paths

## Rebase onto v0.9.1 + #55, #57, #60, #61, #63

Rebased on `master` after six fixes landed. Only `json.go` conflicted:
`appendInternal` now carries both `forceSlow` and #61's zero-on-error block.
Three follow-up commits:

1. **Port #57 into the fast paths.** `encodeStructPlain` and
   `encodeStructIndented` were written against the pre-#57 `encodeStruct` and
   had the same two defects: the rollback point was captured after the
   separator, and the indented form split the newline decision between field
   count and emitted count. After the rebase, five nil-embed cases from #57's
   test and this PR's own parity test (empty struct with an indent prefix)
   failed on the fast path. Fixed with the same changes as `encodeStruct`.
2. **Parity test extended.** New values cover a nil embedded struct pointer
   in every position, omitempty through an embedded pointer, an all-omitempty
   struct nested under indentation, and encode failures inside a struct,
   array, map and nested array. When both paths fail, the error text is now
   compared rather than stopping at both being non-nil.
3. **Omitempty wrapper gated on the tag.** The emptiness wrapper from #60 is
   only consulted for omitempty fields, so it is now only installed for them.
   The pointer-embed promotion moved into a helper to keep
   `appendStructFields` under the complexity limit.

The seven review comments about indenter depth leaking on early error returns
describe #58, fixed in #61 at the `appendInternal` choke point, which this
rebase picks up. The #61 regression test uses an encoder without colors, so it
exercises these fast paths.

`BenchmarkFastVsSlow` after the port (n=5 means, M1 Max): flat 208 ns fast vs
224 ns slow; indent 248 ns fast vs 274 ns slow.

4. **Buffer rollback on error in the unsorted map branches.** The second
   Copilot pass found the fast-path RawMessage map variants returning a
   partial object on error where the slow path returns `b[:start]` (the #63
   convention). The same partial return was in the `map[string]interface{}`
   fast paths and, pre-existing, in the slow branch they mirror. All five now
   roll back to the entry length. The parity test compares bytes on the error
   path too, and a new test drives single-key maps through the unsorted
   branches on both paths with a non-empty input buffer.
