### PR TITLE
Fall back to Colors.String when Colors.TextMarshaler is unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ func DefaultColors() *Colors {
     Bytes:  Color("\x1b[2m"),
     Time:   Color("\x1b[32;2m"),
     Punc:   Color{}, // No colorization
+    // The granular punctuation fields (Brackets, Braces, Comma,
+    // Colon) are intentionally left as the zero value so that they
+    // fall back to Punc, preserving the default (uncolored)
+    // punctuation behavior.
+    TextMarshaler: Color("\x1b[32m"), // Same as String
   }
 }
 ```

--- a/encode.go
+++ b/encode.go
@@ -1048,7 +1048,7 @@ func (e encoder) encodeTextMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 		return e.doEncodeString(b, unsafe.Pointer(&s))
 	}
 
-	b = append(b, e.clrs.TextMarshaler...)
+	b = append(b, e.clrs.textMarshalerColor()...)
 	b, err = e.doEncodeString(b, unsafe.Pointer(&s))
 	b = append(b, ansiReset...)
 	return b, err

--- a/jsoncolor.go
+++ b/jsoncolor.go
@@ -62,6 +62,7 @@ type Colors struct {
 	Colon Color
 
 	// TextMarshaler is the color for values implementing encoding.TextMarshaler.
+	// When unset (the zero value), it falls back to String.
 	TextMarshaler Color
 }
 
@@ -154,6 +155,17 @@ func (c *Colors) puncColor(v byte) Color {
 		return c.Punc
 	}
 	return clr
+}
+
+// textMarshalerColor returns the Color to use for values implementing
+// encoding.TextMarshaler. When TextMarshaler is the zero value (unset), it
+// falls back to String. This preserves backward compatibility for callers
+// written before TextMarshaler was added to Colors.
+func (c *Colors) textMarshalerColor() Color {
+	if len(c.TextMarshaler) == 0 {
+		return c.String
+	}
+	return c.TextMarshaler
 }
 
 // Color is used to render terminal colors. In effect, Color is

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -593,6 +593,50 @@ func TestEncode_TextMarshaler(t *testing.T) {
 		"expected TextMarshaler encoding to use Colors.TextMarshaler")
 }
 
+// TestEncode_TextMarshaler_FallbackToString verifies that when
+// Colors.TextMarshaler is unset (the zero value), values implementing
+// encoding.TextMarshaler are colored with Colors.String, and that an
+// explicitly set Colors.TextMarshaler takes precedence over Colors.String.
+// See issue #53.
+func TestEncode_TextMarshaler_FallbackToString(t *testing.T) {
+	const (
+		str   = "\x1b[32m" // green (String)
+		tmClr = "\x1b[36m" // cyan (TextMarshaler)
+		reset = "\x1b[0m"
+	)
+
+	testCases := []struct {
+		name string
+		clrs *jsoncolor.Colors
+		want string
+	}{
+		{
+			name: "unset TextMarshaler falls back to String",
+			clrs: &jsoncolor.Colors{String: jsoncolor.Color(str)},
+			want: str + `"example text"` + reset + "\n",
+		},
+		{
+			name: "explicit TextMarshaler overrides String",
+			clrs: &jsoncolor.Colors{
+				String:        jsoncolor.Color(str),
+				TextMarshaler: jsoncolor.Color(tmClr),
+			},
+			want: tmClr + `"example text"` + reset + "\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			enc := jsoncolor.NewEncoder(buf)
+			enc.SetColors(tc.clrs)
+
+			require.NoError(t, enc.Encode(TextMarshaler{Text: "example text"}))
+			require.Equal(t, tc.want, buf.String())
+		})
+	}
+}
+
 // puncEncode encodes v with the given Colors and returns the output, using
 // no-HTML-escaping and sorted map keys so output is deterministic.
 func puncEncode(t *testing.T, clrs *jsoncolor.Colors, v interface{}) string {


### PR DESCRIPTION
## Summary

A non-nil `Colors` with `TextMarshaler` left unset produced an uncolored token
followed by a stray `\x1b[0m` for any value implementing
`encoding.TextMarshaler`, because the colorization guard is per-palette rather
than per-field. Every caller written before `TextMarshaler` was added in v0.7.0
is affected, including sq, whose `kind.Kind` implements `MarshalText` and shows
up in `sq inspect --json` output.

This adds `Colors.textMarshalerColor`, which returns `String` when
`TextMarshaler` is unset, mirroring the `puncColor` fallback used by the
granular punctuation fields. The field doc now states the fallback, and a new
table test covers both the fallback and the explicit-override case.
`DefaultColors()` already sets `TextMarshaler` to the String color, so the
default palette is unchanged.

A second commit syncs the README's `DefaultColors()` snippet with the source.
It predated both the granular punctuation fields and `TextMarshaler`.

The broader asymmetry, where any empty `Color` on a non-nil palette still emits
a trailing reset, is tracked separately in #54.

Closes #53

## Checklist

- [x] Tests added or updated (regression test for bug fixes)
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] CHANGELOG entry added to `README.md` under the current version heading. v0.9.1 is already tagged, so this belongs under the next version heading when that is created at release time.
