### PR TITLE
Capture struct rollback point before the field separator

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -695,10 +695,6 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 
 	b = e.clrs.appendPunc(b, '{')
 
-	if len(st.fields) > 0 {
-		b = e.indentr.appendByte(b, '\n')
-	}
-
 	e.indentr.push()
 
 	for i := range st.fields {
@@ -709,15 +705,16 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			continue
 		}
 
-		// Capture the rollback point before the separator so that a
-		// rolled-back field (e.g. a nil embedded struct pointer) does not
-		// leave a dangling comma behind. See issue #56.
-		lengthBeforeKey := len(b)
+		// fieldStart is the rollback point: everything appended for this
+		// field, including its separator, is discarded if the field's codec
+		// returns rollback (e.g. a nil embedded struct pointer). See #56.
+		fieldStart := len(b)
 
 		if n != 0 {
 			b = e.clrs.appendPunc(b, ',')
-			b = e.indentr.appendByte(b, '\n')
 		}
+
+		b = e.indentr.appendByte(b, '\n')
 
 		if (e.flags & EscapeHTML) != 0 {
 			k = f.html
@@ -741,7 +738,7 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 
 		if b, err = f.codec.encode(e, b, v); err != nil {
 			if errors.Is(err, rollback{}) {
-				b = b[:lengthBeforeKey]
+				b = b[:fieldStart]
 				continue
 			}
 			return b[:start], err
@@ -750,12 +747,12 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		n++
 	}
 
+	e.indentr.pop()
+
 	if n > 0 {
 		b = e.indentr.appendByte(b, '\n')
+		b = e.indentr.appendIndent(b)
 	}
-
-	e.indentr.pop()
-	b = e.indentr.appendIndent(b)
 
 	b = e.clrs.appendPunc(b, '}')
 	return b, nil

--- a/encode.go
+++ b/encode.go
@@ -709,6 +709,11 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			continue
 		}
 
+		// Capture the rollback point before the separator so that a
+		// rolled-back field (e.g. a nil embedded struct pointer) does not
+		// leave a dangling comma behind. See issue #56.
+		lengthBeforeKey := len(b)
+
 		if n != 0 {
 			b = e.clrs.appendPunc(b, ',')
 			b = e.indentr.appendByte(b, '\n')
@@ -720,7 +725,6 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			k = f.json
 		}
 
-		lengthBeforeKey := len(b)
 		b = e.indentr.appendIndent(b)
 
 		if e.clrs == nil {

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"regexp"
 	"testing"
 
 	"github.com/segmentio/encoding/json"
@@ -736,4 +737,79 @@ func TestAppendIndenter(t *testing.T) {
 	b, err = jsoncolor.Append(nil, m, jsoncolor.EscapeHTML|jsoncolor.SortMapKeys, nil, disabled)
 	require.NoError(t, err)
 	require.Equal(t, `{"a":1}`, string(b))
+}
+
+// nilEmbedInner is embedded by pointer in the structs below. When the pointer
+// is nil, the encoder must roll back the promoted field cleanly.
+type nilEmbedInner struct {
+	X int
+}
+
+type nilEmbedFirst struct {
+	*nilEmbedInner
+	A int
+	C int
+}
+
+type nilEmbedMiddle struct {
+	A int
+	*nilEmbedInner
+	C int
+}
+
+type nilEmbedLast struct {
+	A int
+	C int
+	*nilEmbedInner
+}
+
+// ansiRe matches ANSI SGR escape sequences.
+var ansiRe = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+// TestEncode_NilEmbeddedStructPointer verifies that a nil embedded struct
+// pointer does not leave a dangling separator behind when its promoted field
+// is rolled back, regardless of position, colorization or indentation.
+// See issue #56.
+func TestEncode_NilEmbeddedStructPointer(t *testing.T) {
+	values := []interface{}{
+		nilEmbedFirst{A: 1, C: 2},
+		nilEmbedMiddle{A: 1, C: 2},
+		nilEmbedLast{A: 1, C: 2},
+	}
+
+	palettes := map[string]*jsoncolor.Colors{
+		"nocolor": nil,
+		"color":   jsoncolor.DefaultColors(),
+	}
+
+	for _, v := range values {
+		for palName, clrs := range palettes {
+			for _, indent := range []bool{false, true} {
+				name := fmt.Sprintf("%T/%s/indent=%v", v, palName, indent)
+				t.Run(name, func(t *testing.T) {
+					want, err := stdjson.Marshal(v)
+					require.NoError(t, err)
+
+					buf := &bytes.Buffer{}
+					enc := jsoncolor.NewEncoder(buf)
+					enc.SetColors(clrs)
+					if indent {
+						enc.SetIndent("", "  ")
+					}
+					require.NoError(t, enc.Encode(v))
+
+					got := ansiRe.ReplaceAll(buf.Bytes(), nil)
+					require.True(t, stdjson.Valid(got), "invalid JSON: %q", got)
+
+					compact := &bytes.Buffer{}
+					require.NoError(t, stdjson.Compact(compact, got))
+					require.Equal(t, string(want), compact.String())
+
+					if clrs == nil && !indent {
+						require.Equal(t, string(want)+"\n", buf.String())
+					}
+				})
+			}
+		}
+	}
 }

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -745,6 +745,10 @@ type nilEmbedInner struct {
 	X int
 }
 
+type nilEmbedOnly struct {
+	*nilEmbedInner
+}
+
 type nilEmbedFirst struct {
 	*nilEmbedInner
 	A int
@@ -767,47 +771,50 @@ type nilEmbedLast struct {
 var ansiRe = regexp.MustCompile("\x1b\\[[0-9;]*m")
 
 // TestEncode_NilEmbeddedStructPointer verifies that a nil embedded struct
-// pointer does not leave a dangling separator behind when its promoted field
-// is rolled back, regardless of position, colorization or indentation.
+// pointer does not leave a dangling separator or newline behind when its
+// promoted field is rolled back, regardless of position, colorization or
+// indentation. Output (with ANSI stripped) must match encoding/json exactly.
 // See issue #56.
 func TestEncode_NilEmbeddedStructPointer(t *testing.T) {
 	values := []interface{}{
+		nilEmbedOnly{},
 		nilEmbedFirst{A: 1, C: 2},
 		nilEmbedMiddle{A: 1, C: 2},
 		nilEmbedLast{A: 1, C: 2},
 	}
 
-	palettes := map[string]*jsoncolor.Colors{
-		"nocolor": nil,
-		"color":   jsoncolor.DefaultColors(),
+	palettes := []struct {
+		name string
+		clrs *jsoncolor.Colors
+	}{
+		{name: "nocolor", clrs: nil},
+		{name: "color", clrs: jsoncolor.DefaultColors()},
 	}
 
 	for _, v := range values {
-		for palName, clrs := range palettes {
+		for _, pal := range palettes {
 			for _, indent := range []bool{false, true} {
-				name := fmt.Sprintf("%T/%s/indent=%v", v, palName, indent)
+				name := fmt.Sprintf("%T/%s/indent=%v", v, pal.name, indent)
 				t.Run(name, func(t *testing.T) {
-					want, err := stdjson.Marshal(v)
+					var want []byte
+					var err error
+					if indent {
+						want, err = stdjson.MarshalIndent(v, "", "  ")
+					} else {
+						want, err = stdjson.Marshal(v)
+					}
 					require.NoError(t, err)
 
 					buf := &bytes.Buffer{}
 					enc := jsoncolor.NewEncoder(buf)
-					enc.SetColors(clrs)
+					enc.SetColors(pal.clrs)
 					if indent {
 						enc.SetIndent("", "  ")
 					}
 					require.NoError(t, enc.Encode(v))
 
 					got := ansiRe.ReplaceAll(buf.Bytes(), nil)
-					require.True(t, stdjson.Valid(got), "invalid JSON: %q", got)
-
-					compact := &bytes.Buffer{}
-					require.NoError(t, stdjson.Compact(compact, got))
-					require.Equal(t, string(want), compact.String())
-
-					if clrs == nil && !indent {
-						require.Equal(t, string(want)+"\n", buf.String())
-					}
+					require.Equal(t, string(want)+"\n", string(got))
 				})
 			}
 		}


### PR DESCRIPTION
## Summary

When a struct embeds a nil pointer to a struct, the promoted field's codec
returns `rollback{}` and `encodeStruct` truncates the buffer back to the key.
The truncation point was captured after the `,` separator (and newline, when
indenting) had already been appended, so the separator survived the rollback.
A nil embed between other fields produced `{"A":1,,"C":2}` and a nil embed in
last position produced `{"A":1,"C":2,}`, both invalid JSON. `encoding/json`
handles both correctly, and upstream segmentio captures the rollback point
before the separator, so this is drift from the v0.1.14 fork.

Two commits:

1. Move the rollback capture (now `fieldStart`) ahead of the separator.
2. Emit the per-field newline inside the loop, next to the separator, so the
   emitted-field counter owns the comma, the newline and the closing indent,
   matching `encodeArray`. Previously the opening newline was written whenever
   the type had fields but the closing one only when a field was emitted, so a
   struct whose every field was rolled back or omitempty-skipped rendered as
   `{` newline `}` under `SetIndent` where `encoding/json` renders `{}`.

The regression test encodes a nil embed as the only field and in first, middle
and last position, with nil colors and `DefaultColors()`, compact and indented.
Each output is stripped of ANSI and compared byte for byte with `Marshal` or
`MarshalIndent`. Ten of the sixteen subtests failed before the fixes.

Review of this PR also surfaced two pre-existing bugs in the same loop, filed
separately: #58 (indenter depth leaks after a failed Encode) and #59
(omitempty through an embedded struct pointer checks the wrong memory).

Note for #45: `encodeStructPlain` and `encodeStructIndented` there copy the old
ordering and will need the same changes, and that branch will conflict with
this one on `encodeStruct`.

Closes #56

## Checklist

- [x] Tests added or updated (regression test for bug fixes)
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] CHANGELOG entry added to `README.md` under the current version heading. v0.9.1 is already tagged, so this belongs under the next version heading when that is created at release time.
