### PR TITLE
Evaluate omitempty through embedded struct pointers at the promoted field

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,9 +38,9 @@ jobs:
       run: go build -v .
 
     - name: Test
-      run: go test -v .
+      run: go test -v ./...
 
     # The race detector also enables checkptr, which catches unsafe.Pointer
     # arithmetic that reads outside an allocation (see issue #59).
     - name: Test (race detector)
-      run: go test -race .
+      run: go test -race ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,3 +39,8 @@ jobs:
 
     - name: Test
       run: go test -v .
+
+    # The race detector also enables checkptr, which catches unsafe.Pointer
+    # arithmetic that reads outside an allocation (see issue #59).
+    - name: Test (race detector)
+      run: go test -race .

--- a/codec.go
+++ b/codec.go
@@ -489,6 +489,23 @@ func constructEmbeddedStructPointerCodec(t reflect.Type, unexported bool, offset
 	}
 }
 
+// constructEmbeddedStructPointerEmptyFunc wraps the emptiness check of a
+// field promoted through an embedded struct pointer. Like the codec wrapper
+// above, the returned function receives the address of the pointer word in
+// the outer struct: it dereferences the pointer and applies empty at the
+// field's offset within the embedded struct. A nil pointer is reported as
+// empty. Nested pointer embeds compose naturally, because each level wraps
+// the function produced by the level below. See issue #59.
+func constructEmbeddedStructPointerEmptyFunc(offset uintptr, empty emptyFunc) emptyFunc {
+	return func(p unsafe.Pointer) bool {
+		p = *(*unsafe.Pointer)(p)
+		if p == nil {
+			return true
+		}
+		return empty(unsafe.Pointer(uintptr(p) + offset))
+	}
+}
+
 func constructEmbeddedStructPointerEncodeFunc(t reflect.Type, unexported bool, offset uintptr, encode encodeFunc) encodeFunc {
 	return func(e encoder, b []byte, p unsafe.Pointer) ([]byte, error) {
 		return e.encodeEmbeddedStructPointer(b, p, t, unexported, offset, encode)
@@ -620,6 +637,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 
 		if embfield.pointer {
 			subfield.codec = constructEmbeddedStructPointerCodec(embfield.subtype.typ, embfield.unexported, subfield.offset, subfield.codec)
+			subfield.empty = constructEmbeddedStructPointerEmptyFunc(subfield.offset, subfield.empty)
 			subfield.offset = embfield.offset
 		} else {
 			subfield.offset += embfield.offset

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -864,3 +864,72 @@ func TestEncode_NilEmbeddedStructPointer(t *testing.T) {
 		}
 	}
 }
+
+// The types below exercise omitempty on fields promoted through an embedded
+// struct pointer. See issue #59.
+
+type omitEmbedInner struct {
+	X int    `json:",omitempty"`
+	Y string `json:",omitempty"`
+}
+
+type omitEmbedMiddle struct {
+	A int
+	*omitEmbedInner
+	C int
+}
+
+type omitEmbedSliceInner struct {
+	S []int `json:",omitempty"`
+}
+
+// omitEmbedSliceLast places the embedded pointer as the last field, so an
+// emptiness check that reads the pointer word as a slice header would read
+// past the end of the struct.
+type omitEmbedSliceLast struct {
+	A int
+	*omitEmbedSliceInner
+}
+
+type omitEmbedL2 struct {
+	Z int `json:",omitempty"`
+}
+
+type omitEmbedL1 struct {
+	*omitEmbedL2
+}
+
+// omitEmbedChain promotes Z through two levels of embedded pointers.
+type omitEmbedChain struct {
+	A int
+	*omitEmbedL1
+	C int
+}
+
+// TestEncode_OmitEmptyThroughEmbeddedPointer verifies that omitempty on a
+// field promoted through one or more embedded struct pointers is evaluated
+// against the promoted field itself, not against the pointer word in the
+// outer struct, and that output matches encoding/json exactly.
+func TestEncode_OmitEmptyThroughEmbeddedPointer(t *testing.T) {
+	values := []interface{}{
+		omitEmbedMiddle{A: 1, omitEmbedInner: &omitEmbedInner{}, C: 2},
+		omitEmbedMiddle{A: 1, omitEmbedInner: &omitEmbedInner{X: 5, Y: "y"}, C: 2},
+		omitEmbedMiddle{A: 1, C: 2},
+		omitEmbedSliceLast{A: 1, omitEmbedSliceInner: &omitEmbedSliceInner{}},
+		omitEmbedSliceLast{A: 1, omitEmbedSliceInner: &omitEmbedSliceInner{S: []int{7}}},
+		omitEmbedChain{A: 1, omitEmbedL1: &omitEmbedL1{omitEmbedL2: &omitEmbedL2{}}, C: 2},
+		omitEmbedChain{A: 1, omitEmbedL1: &omitEmbedL1{omitEmbedL2: &omitEmbedL2{Z: 9}}, C: 2},
+		omitEmbedChain{A: 1, omitEmbedL1: &omitEmbedL1{}, C: 2},
+	}
+
+	for i, v := range values {
+		t.Run(fmt.Sprintf("%d_%T", i, v), func(t *testing.T) {
+			want, err := stdjson.Marshal(v)
+			require.NoError(t, err)
+
+			got, err := jsoncolor.Marshal(v)
+			require.NoError(t, err)
+			require.Equal(t, string(want), string(got))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a struct embeds a pointer to a struct, `appendStructFields` wraps each
promoted field's codec so it dereferences the pointer, and re-points the
field's offset at the pointer word in the outer struct. It left the field's
emptiness check untouched, so `omitempty` was evaluated on the pointer word and
the bytes after it rather than on the promoted field. That emitted zero-valued
fields that `encoding/json` omits, and when the embedded pointer was the last
field of the outer struct, a slice or string check read past the end of the
allocation, which the race detector's checkptr reports as a fatal error.

```
encoding/json: {"A":1,"C":2}
jsoncolor:     {"A":1,"X":0,"Y":"","C":2}
```

Two commits:

1. Wrap the emptiness check the same way the codec is wrapped: dereference the
   pointer at the outer offset, treat nil as empty, and apply the original
   check at the field's offset within the embedded struct. Nested pointer
   embeds compose because each level wraps the function produced by the level
   below. The regression test covers set and unset `omitempty` fields through
   one and two levels of embedded pointers, and the pointer-last layout,
   compared byte for byte with `encoding/json`. Three of the eight cases failed
   before the fix, and the race detector aborted on the pointer-last case.
2. Add a CI step that runs the suite under `-race`, which enables checkptr and
   would have caught this. The plain run stays so failures remain attributable.

Upstream `segmentio/encoding` (checked at v0.5.4) has the same omission in its
embedded-pointer handling, so this is inherited rather than fork drift.

Closes #59

## Checklist

- [x] Tests added or updated (regression test for bug fixes)
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] CHANGELOG entry added to `README.md` under the current version heading. v0.9.1 is already tagged, so this belongs under the next version heading when that is created at release time.
