### PR TITLE
Restore indenter depth when Append fails

### DIFF
--- a/json.go
+++ b/json.go
@@ -136,7 +136,21 @@ func Append(b []byte, x interface{}, flags AppendFlags, clrs *Colors, indentr *I
 		c = constructCachedCodec(t, cache)
 	}
 
+	// A failed encode can return from inside a push/pop pair, leaving the
+	// Indenter at a stale depth. Restore the depth this call started at on
+	// error, so a failure cannot poison later calls: Encoder.Encode reuses
+	// its Indenter, and Append re-enters itself for interface, Marshaler and
+	// sorted-map values, so the depth must be restored rather than zeroed.
+	// See issue #58.
+	var depth int
+	if indentr != nil {
+		depth = indentr.depth
+	}
+
 	b, err := c.encode(encoder{flags: flags, clrs: clrs, indentr: indentr}, b, p)
+	if err != nil && indentr != nil {
+		indentr.depth = depth
+	}
 	runtime.KeepAlive(x)
 	return b, err
 }

--- a/json.go
+++ b/json.go
@@ -136,20 +136,16 @@ func Append(b []byte, x interface{}, flags AppendFlags, clrs *Colors, indentr *I
 		c = constructCachedCodec(t, cache)
 	}
 
-	// A failed encode can return from inside a push/pop pair, leaving the
-	// Indenter at a stale depth. Restore the depth this call started at on
-	// error, so a failure cannot poison later calls: Encoder.Encode reuses
-	// its Indenter, and Append re-enters itself for interface, Marshaler and
-	// sorted-map values, so the depth must be restored rather than zeroed.
-	// See issue #58.
-	var depth int
-	if indentr != nil {
-		depth = indentr.depth
-	}
-
 	b, err := c.encode(encoder{flags: flags, clrs: clrs, indentr: indentr}, b, p)
 	if err != nil && indentr != nil {
-		indentr.depth = depth
+		// A failed encode can return from inside a push/pop pair, leaving
+		// the Indenter at a stale depth that would poison later calls, since
+		// Encoder.Encode reuses its Indenter. Every caller enters the
+		// outermost Append at depth zero, and the re-entrant calls made for
+		// interface, Marshaler and sorted-map values all unwind with the
+		// same error, so zeroing here leaves the outermost caller with a
+		// clean Indenter. See issue #58.
+		indentr.depth = 0
 	}
 	runtime.KeepAlive(x)
 	return b, err

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -933,3 +933,60 @@ func TestEncode_OmitEmptyThroughEmbeddedPointer(t *testing.T) {
 		})
 	}
 }
+
+// indentLeakMarshaler implements json.Marshaler, returning an object so that
+// the encoder re-enters its indenting logic for the nested value.
+type indentLeakMarshaler struct{}
+
+func (indentLeakMarshaler) MarshalJSON() ([]byte, error) {
+	return []byte(`{"k":[1,2]}`), nil
+}
+
+// TestEncode_IndentDepthAfterFailedEncode verifies that an Encode that fails
+// partway through a struct, array or map does not leave the Encoder's
+// indenter at a stale depth, so that the next Encode on the same Encoder is
+// indented exactly as encoding/json would. It also verifies that a nested
+// json.Marshaler value, which re-enters the encoder mid-encode, still indents
+// correctly after a prior failure. See issue #58.
+func TestEncode_IndentDepthAfterFailedEncode(t *testing.T) {
+	type inner struct{ F func() }
+	type outer struct{ Bad inner }
+	type withMarshaler struct {
+		A int
+		M indentLeakMarshaler
+	}
+
+	failing := []interface{}{
+		outer{},                      // fails two struct levels deep
+		[]func(){nil},                // fails inside an array
+		map[string]func(){"a": nil},  // fails inside a map
+		[]interface{}{[]func(){nil}}, // fails inside a nested array
+	}
+
+	followUps := []interface{}{
+		map[string]int{"a": 1},
+		[]int{1, 2},
+		withMarshaler{A: 1},
+	}
+
+	for _, bad := range failing {
+		for _, good := range followUps {
+			name := fmt.Sprintf("%T_then_%T", bad, good)
+			t.Run(name, func(t *testing.T) {
+				wantBuf := &bytes.Buffer{}
+				stdEnc := stdjson.NewEncoder(wantBuf)
+				stdEnc.SetIndent("", "  ")
+				require.NoError(t, stdEnc.Encode(good))
+
+				buf := &bytes.Buffer{}
+				enc := jsoncolor.NewEncoder(buf)
+				enc.SetIndent("", "  ")
+				require.Error(t, enc.Encode(bad))
+
+				buf.Reset()
+				require.NoError(t, enc.Encode(good))
+				require.Equal(t, wantBuf.String(), buf.String())
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`encodeStruct`, `encodeArray` and the map encoders push the indenter depth
before walking their elements, and their error paths return without popping
it. `Encoder.Encode` reuses its `Indenter` across calls and nothing reset the
depth, so one failed `Encode` left every later `Encode` on the same `Encoder`
over-indented by the depth at which the failure occurred.

```
after a failed Encode: "{\n      \"a\": 1\n    }\n"
expected:              "{\n  \"a\": 1\n}\n"
```

The fix is confined to `Append`: when the encode returns an error, zero the
indenter depth. That covers every early-return path without touching the
individual encoders. Every supported caller enters the outermost `Append` at
depth zero, and the re-entrant calls `Append` makes for interface,
`json.Marshaler` and sorted-map values all unwind with the same error, so the
outermost caller is left with a clean `Indenter`.

The first commit saved the depth on entry and restored it on error. That form
measured about 2% slower on `BenchmarkEncode/neilotoole_NoIndent_NoColor`
against `master`, because the re-entrant calls paid the nil check and load on
every interface value. The second commit switches to zero-on-error, which is
not statistically distinguishable from `master` at n=8.

The regression test fails an `Encode` inside a struct, an array, a map and a
nested array, then encodes a map, a slice and a struct containing a
`json.Marshaler` on the same `Encoder`, comparing each with `encoding/json`'s
`SetIndent` output. All twelve combinations failed before the fix.

Closes #58

## Checklist

- [x] Tests added or updated (regression test for bug fixes)
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] CHANGELOG entry added to `README.md` under the current version heading. v0.9.1 is already tagged, so this belongs under the next version heading when that is created at release time.
