### PR TITLE
Return the error from an invalid RawMessage in an unsorted map

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -589,6 +589,8 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 		return e.clrs.appendNull(b), nil
 	}
 
+	start := len(b)
+
 	if (e.flags & SortMapKeys) == 0 {
 		// Optimized code path when the program does not need the map keys to be
 		// sorted.
@@ -622,8 +624,11 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 
 				i++
 			}
-			b = e.indentr.appendByte(b, '\n')
 			e.indentr.pop()
+			if err != nil {
+				return b[:start], err
+			}
+			b = e.indentr.appendByte(b, '\n')
 			b = e.indentr.appendIndent(b)
 		}
 
@@ -640,7 +645,6 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 	}
 	sort.Sort(s)
 
-	start := len(b)
 	var err error
 	b = e.clrs.appendPunc(b, '{')
 

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -990,3 +990,51 @@ func TestEncode_IndentDepthAfterFailedEncode(t *testing.T) {
 		}
 	}
 }
+
+// TestEncode_MapStringRawMessage_InvalidValue verifies that an invalid
+// RawMessage value in a map[string]RawMessage produces an error regardless of
+// whether map keys are sorted or output is indented, and that a valid map
+// still encodes correctly on both paths. See issue #62.
+func TestEncode_MapStringRawMessage_InvalidValue(t *testing.T) {
+	invalid := map[string]jsoncolor.RawMessage{
+		"a": jsoncolor.RawMessage(`{"x":1}`),
+		"b": jsoncolor.RawMessage(`{bad`),
+	}
+	valid := map[string]jsoncolor.RawMessage{
+		"a": jsoncolor.RawMessage(`{"x":1}`),
+		"b": jsoncolor.RawMessage(`[1,2]`),
+	}
+
+	for _, sorted := range []bool{false, true} {
+		for _, indent := range []bool{false, true} {
+			name := fmt.Sprintf("sorted=%v/indent=%v", sorted, indent)
+			t.Run(name, func(t *testing.T) {
+				newEnc := func(buf *bytes.Buffer) *jsoncolor.Encoder {
+					enc := jsoncolor.NewEncoder(buf)
+					enc.SetSortMapKeys(sorted)
+					if indent {
+						enc.SetIndent("", "  ")
+					}
+					return enc
+				}
+
+				buf := &bytes.Buffer{}
+				require.Error(t, newEnc(buf).Encode(invalid))
+				require.Empty(t, buf.String(), "nothing should be written on error")
+
+				buf.Reset()
+				require.NoError(t, newEnc(buf).Encode(valid))
+				require.True(t, stdjson.Valid(buf.Bytes()), "invalid JSON: %q", buf.String())
+
+				// Semantic comparison with encoding/json, since the unsorted
+				// path may emit keys in any order.
+				var got, want interface{}
+				require.NoError(t, stdjson.Unmarshal(buf.Bytes(), &got))
+				wantBytes, err := stdjson.Marshal(valid)
+				require.NoError(t, err)
+				require.NoError(t, stdjson.Unmarshal(wantBytes, &want))
+				require.Equal(t, want, got)
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`encodeMapStringRawMessage` has two paths. The sorted path returns the error
from an invalid `RawMessage` value. The unsorted path, which is the default,
broke out of its loop on error, then closed the object and returned `nil`, so
the caller got no error and truncated, invalid JSON. `encoding/json` returns an
error in both cases.

```
input:  map[string]RawMessage{"a": `{"x":1}`, "b": `{bad`}
before: err=nil, output {"a":{"x":1},"b":}
after:  err="json: unsupported value: ...", no output
```

The fix hoists the `start` marker above both branches and returns the error
after the unsorted loop, mirroring the sorted branch.

The test requires an error for an invalid value with map keys sorted and
unsorted, compact and indented, checks that nothing is written on error, and
confirms a valid map still encodes on both paths by semantic comparison with
`encoding/json`. Both unsorted cases failed before the fix.

Closes #62

## Checklist

- [x] Tests added or updated (regression test for bug fixes)
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] CHANGELOG entry added to `README.md` under the current version heading. v0.9.1 is already tagged, so this belongs under the next version heading when that is created at release time.
