### PR TITLE
Emit no ANSI reset for an empty Color

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -112,26 +112,26 @@ func (e encoder) encodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeFloat32(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil {
+	if e.clrs == nil || len(e.clrs.Number) == 0 {
 		return e.encodeFloat(b, float64(*(*float32)(p)), 32)
 	}
 
 	b = append(b, e.clrs.Number...)
 	var err error
 	b, err = e.encodeFloat(b, float64(*(*float32)(p)), 32)
-	b = appendReset(b, e.clrs.Number)
+	b = append(b, ansiReset...)
 	return b, err
 }
 
 func (e encoder) encodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil {
+	if e.clrs == nil || len(e.clrs.Number) == 0 {
 		return e.encodeFloat(b, *(*float64)(p), 64)
 	}
 
 	b = append(b, e.clrs.Number...)
 	var err error
 	b, err = e.encodeFloat(b, *(*float64)(p), 64)
-	b = appendReset(b, e.clrs.Number)
+	b = append(b, ansiReset...)
 	return b, err
 }
 
@@ -182,37 +182,37 @@ func (e encoder) encodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b, err
 	}
 
-	if e.clrs == nil {
+	if e.clrs == nil || len(e.clrs.Number) == 0 {
 		return append(b, n...), nil
 	}
 
 	b = append(b, e.clrs.Number...)
 	b = append(b, n...)
-	b = appendReset(b, e.clrs.Number)
+	b = append(b, ansiReset...)
 	return b, nil
 }
 
 func (e encoder) encodeKey(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil {
+	if e.clrs == nil || len(e.clrs.Key) == 0 {
 		return e.doEncodeString(b, p)
 	}
 
 	b = append(b, e.clrs.Key...)
 	var err error
 	b, err = e.doEncodeString(b, p)
-	b = appendReset(b, e.clrs.Key)
+	b = append(b, ansiReset...)
 	return b, err
 }
 
 func (e encoder) encodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil {
+	if e.clrs == nil || len(e.clrs.String) == 0 {
 		return e.doEncodeString(b, p)
 	}
 
 	b = append(b, e.clrs.String...)
 	var err error
 	b, err = e.doEncodeString(b, p)
-	b = appendReset(b, e.clrs.String)
+	b = append(b, ansiReset...)
 	return b, err
 }
 
@@ -336,14 +336,14 @@ func (e encoder) encodeToString(b []byte, p unsafe.Pointer, encode encodeFunc) (
 }
 
 func (e encoder) encodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil {
+	if e.clrs == nil || len(e.clrs.Bytes) == 0 {
 		return e.doEncodeBytes(b, p)
 	}
 
 	b = append(b, e.clrs.Bytes...)
 	var err error
 	b, err = e.doEncodeBytes(b, p)
-	return appendReset(b, e.clrs.Bytes), err
+	return append(b, ansiReset...), err
 }
 
 func (e encoder) doEncodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
@@ -399,7 +399,7 @@ func (e encoder) encodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil {
+	if e.clrs == nil || len(e.clrs.Time) == 0 {
 		t := *(*time.Time)(p)
 		b = append(b, '"')
 		b = t.AppendFormat(b, time.RFC3339Nano)
@@ -412,7 +412,7 @@ func (e encoder) encodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
 	b = append(b, '"')
 	b = t.AppendFormat(b, time.RFC3339Nano)
 	b = append(b, '"')
-	b = appendReset(b, e.clrs.Time)
+	b = append(b, ansiReset...)
 	return b, nil
 }
 
@@ -1208,12 +1208,12 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 
 		b = e.indentr.appendIndent(b)
 
-		if e.clrs == nil {
+		if e.clrs == nil || len(e.clrs.Key) == 0 {
 			b = append(b, k...)
 		} else {
 			b = append(b, e.clrs.Key...)
 			b = append(b, k...)
-			b = appendReset(b, e.clrs.Key)
+			b = append(b, ansiReset...)
 		}
 
 		b = e.clrs.appendPunc(b, ':')
@@ -1557,25 +1557,27 @@ func (e encoder) appendRawMessageItemPrefix(b []byte, stack []rawFrame, isKey bo
 func (e encoder) appendRawMessageScalar(b []byte, v RawValue, isKey bool) []byte {
 	escapeHTML := (e.flags & EscapeHTML) != 0
 
-	if e.clrs == nil {
+	var clr Color
+	if e.clrs != nil {
+		switch {
+		case isKey:
+			clr = e.clrs.Key
+		case v.String():
+			clr = e.clrs.String
+		case v.Number():
+			clr = e.clrs.Number
+		case v.True(), v.False():
+			clr = e.clrs.Bool
+		case v.Null():
+			clr = e.clrs.Null
+		}
+	}
+
+	if len(clr) == 0 {
 		if escapeHTML && v.String() {
 			return appendCompactEscapeHTML(b, v)
 		}
 		return append(b, v...)
-	}
-
-	var clr Color
-	switch {
-	case isKey:
-		clr = e.clrs.Key
-	case v.String():
-		clr = e.clrs.String
-	case v.Number():
-		clr = e.clrs.Number
-	case v.True(), v.False():
-		clr = e.clrs.Bool
-	case v.Null():
-		clr = e.clrs.Null
 	}
 
 	b = append(b, clr...)
@@ -1584,7 +1586,7 @@ func (e encoder) appendRawMessageScalar(b []byte, v RawValue, isKey bool) []byte
 	} else {
 		b = append(b, v...)
 	}
-	return appendReset(b, clr)
+	return append(b, ansiReset...)
 }
 
 // encodeJSONMarshaler suffers from the same defect as encodeRawMessage; it
@@ -1638,9 +1640,13 @@ func (e encoder) encodeTextMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 	}
 
 	clr := e.clrs.textMarshalerColor()
+	if len(clr) == 0 {
+		return e.doEncodeString(b, unsafe.Pointer(&s))
+	}
+
 	b = append(b, clr...)
 	b, err = e.doEncodeString(b, unsafe.Pointer(&s))
-	b = appendReset(b, clr)
+	b = append(b, ansiReset...)
 	return b, err
 }
 

--- a/encode.go
+++ b/encode.go
@@ -119,7 +119,7 @@ func (e encoder) encodeFloat32(b []byte, p unsafe.Pointer) ([]byte, error) {
 	b = append(b, e.clrs.Number...)
 	var err error
 	b, err = e.encodeFloat(b, float64(*(*float32)(p)), 32)
-	b = append(b, ansiReset...)
+	b = appendReset(b, e.clrs.Number)
 	return b, err
 }
 
@@ -131,7 +131,7 @@ func (e encoder) encodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
 	b = append(b, e.clrs.Number...)
 	var err error
 	b, err = e.encodeFloat(b, *(*float64)(p), 64)
-	b = append(b, ansiReset...)
+	b = appendReset(b, e.clrs.Number)
 	return b, err
 }
 
@@ -188,7 +188,7 @@ func (e encoder) encodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	b = append(b, e.clrs.Number...)
 	b = append(b, n...)
-	b = append(b, ansiReset...)
+	b = appendReset(b, e.clrs.Number)
 	return b, nil
 }
 
@@ -200,7 +200,7 @@ func (e encoder) encodeKey(b []byte, p unsafe.Pointer) ([]byte, error) {
 	b = append(b, e.clrs.Key...)
 	var err error
 	b, err = e.doEncodeString(b, p)
-	b = append(b, ansiReset...)
+	b = appendReset(b, e.clrs.Key)
 	return b, err
 }
 
@@ -212,7 +212,7 @@ func (e encoder) encodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
 	b = append(b, e.clrs.String...)
 	var err error
 	b, err = e.doEncodeString(b, p)
-	b = append(b, ansiReset...)
+	b = appendReset(b, e.clrs.String)
 	return b, err
 }
 
@@ -343,7 +343,7 @@ func (e encoder) encodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
 	b = append(b, e.clrs.Bytes...)
 	var err error
 	b, err = e.doEncodeBytes(b, p)
-	return append(b, ansiReset...), err
+	return appendReset(b, e.clrs.Bytes), err
 }
 
 func (e encoder) doEncodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
@@ -412,7 +412,7 @@ func (e encoder) encodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
 	b = append(b, '"')
 	b = t.AppendFormat(b, time.RFC3339Nano)
 	b = append(b, '"')
-	b = append(b, ansiReset...)
+	b = appendReset(b, e.clrs.Time)
 	return b, nil
 }
 
@@ -1213,7 +1213,7 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		} else {
 			b = append(b, e.clrs.Key...)
 			b = append(b, k...)
-			b = append(b, ansiReset...)
+			b = appendReset(b, e.clrs.Key)
 		}
 
 		b = e.clrs.appendPunc(b, ':')
@@ -1584,7 +1584,7 @@ func (e encoder) appendRawMessageScalar(b []byte, v RawValue, isKey bool) []byte
 	} else {
 		b = append(b, v...)
 	}
-	return append(b, ansiReset...)
+	return appendReset(b, clr)
 }
 
 // encodeJSONMarshaler suffers from the same defect as encodeRawMessage; it
@@ -1637,9 +1637,10 @@ func (e encoder) encodeTextMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 		return e.doEncodeString(b, unsafe.Pointer(&s))
 	}
 
-	b = append(b, e.clrs.textMarshalerColor()...)
+	clr := e.clrs.textMarshalerColor()
+	b = append(b, clr...)
 	b, err = e.doEncodeString(b, unsafe.Pointer(&s))
-	b = append(b, ansiReset...)
+	b = appendReset(b, clr)
 	return b, err
 }
 

--- a/jsoncolor.go
+++ b/jsoncolor.go
@@ -66,31 +66,20 @@ type Colors struct {
 	TextMarshaler Color
 }
 
-// appendReset appends the ANSI reset code to b if clr is non-empty. An
-// empty Color writes no prefix, so it must write no reset either; otherwise
-// a partially populated palette would leave a bare reset after every
-// uncolored token. See issue #54.
-func appendReset(b []byte, clr Color) []byte {
-	if len(clr) == 0 {
-		return b
-	}
-	return append(b, ansiReset...)
-}
-
 // appendNull appends a colorized "null" to b.
 func (c *Colors) appendNull(b []byte) []byte {
-	if c == nil {
+	if c == nil || len(c.Null) == 0 {
 		return append(b, "null"...)
 	}
 
 	b = append(b, c.Null...)
 	b = append(b, "null"...)
-	return appendReset(b, c.Null)
+	return append(b, ansiReset...)
 }
 
 // appendBool appends the colorized bool v to b.
 func (c *Colors) appendBool(b []byte, v bool) []byte {
-	if c == nil {
+	if c == nil || len(c.Bool) == 0 {
 		if v {
 			return append(b, "true"...)
 		}
@@ -105,29 +94,29 @@ func (c *Colors) appendBool(b []byte, v bool) []byte {
 		b = append(b, "false"...)
 	}
 
-	return appendReset(b, c.Bool)
+	return append(b, ansiReset...)
 }
 
 // appendInt64 appends the colorized int64 v to b.
 func (c *Colors) appendInt64(b []byte, v int64) []byte {
-	if c == nil {
+	if c == nil || len(c.Number) == 0 {
 		return strconv.AppendInt(b, v, 10)
 	}
 
 	b = append(b, c.Number...)
 	b = strconv.AppendInt(b, v, 10)
-	return appendReset(b, c.Number)
+	return append(b, ansiReset...)
 }
 
 // appendUint64 appends the colorized uint64 v to b.
 func (c *Colors) appendUint64(b []byte, v uint64) []byte {
-	if c == nil {
+	if c == nil || len(c.Number) == 0 {
 		return strconv.AppendUint(b, v, 10)
 	}
 
 	b = append(b, c.Number...)
 	b = strconv.AppendUint(b, v, 10)
-	return appendReset(b, c.Number)
+	return append(b, ansiReset...)
 }
 
 // appendPunc appends the colorized punctuation mark v to b. The color is
@@ -140,9 +129,13 @@ func (c *Colors) appendPunc(b []byte, v byte) []byte {
 	}
 
 	clr := c.puncColor(v)
+	if len(clr) == 0 {
+		return append(b, v)
+	}
+
 	b = append(b, clr...)
 	b = append(b, v)
-	return appendReset(b, clr)
+	return append(b, ansiReset...)
 }
 
 // puncColor returns the Color to use for punctuation mark v. It selects the

--- a/jsoncolor.go
+++ b/jsoncolor.go
@@ -66,6 +66,17 @@ type Colors struct {
 	TextMarshaler Color
 }
 
+// appendReset appends the ANSI reset code to b if clr is non-empty. An
+// empty Color writes no prefix, so it must write no reset either; otherwise
+// a partially populated palette would leave a bare reset after every
+// uncolored token. See issue #54.
+func appendReset(b []byte, clr Color) []byte {
+	if len(clr) == 0 {
+		return b
+	}
+	return append(b, ansiReset...)
+}
+
 // appendNull appends a colorized "null" to b.
 func (c *Colors) appendNull(b []byte) []byte {
 	if c == nil {
@@ -74,7 +85,7 @@ func (c *Colors) appendNull(b []byte) []byte {
 
 	b = append(b, c.Null...)
 	b = append(b, "null"...)
-	return append(b, ansiReset...)
+	return appendReset(b, c.Null)
 }
 
 // appendBool appends the colorized bool v to b.
@@ -94,7 +105,7 @@ func (c *Colors) appendBool(b []byte, v bool) []byte {
 		b = append(b, "false"...)
 	}
 
-	return append(b, ansiReset...)
+	return appendReset(b, c.Bool)
 }
 
 // appendInt64 appends the colorized int64 v to b.
@@ -105,7 +116,7 @@ func (c *Colors) appendInt64(b []byte, v int64) []byte {
 
 	b = append(b, c.Number...)
 	b = strconv.AppendInt(b, v, 10)
-	return append(b, ansiReset...)
+	return appendReset(b, c.Number)
 }
 
 // appendUint64 appends the colorized uint64 v to b.
@@ -116,7 +127,7 @@ func (c *Colors) appendUint64(b []byte, v uint64) []byte {
 
 	b = append(b, c.Number...)
 	b = strconv.AppendUint(b, v, 10)
-	return append(b, ansiReset...)
+	return appendReset(b, c.Number)
 }
 
 // appendPunc appends the colorized punctuation mark v to b. The color is
@@ -128,9 +139,10 @@ func (c *Colors) appendPunc(b []byte, v byte) []byte {
 		return append(b, v)
 	}
 
-	b = append(b, c.puncColor(v)...)
+	clr := c.puncColor(v)
+	b = append(b, clr...)
 	b = append(b, v)
-	return append(b, ansiReset...)
+	return appendReset(b, clr)
 }
 
 // puncColor returns the Color to use for punctuation mark v. It selects the

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/segmentio/encoding/json"
 
@@ -667,10 +669,10 @@ func TestEncode_Punc_OnlyPunc(t *testing.T) {
 	got := puncEncode(t, clrs, v)
 
 	const reset = "\x1b[0m"
-	// When colors are enabled, keys and scalar values render with an
-	// (empty) color prefix followed by a reset suffix.
-	key := func(s string) string { return "\"" + s + "\"" + reset }
-	val := func(s string) string { return s + reset }
+	// Keys and scalar values have no color set, so they render bare: an
+	// empty Color emits neither a prefix nor a reset.
+	key := func(s string) string { return "\"" + s + "\"" }
+	val := func(s string) string { return s }
 	// Every structural punctuation char is wrapped with the Punc color.
 	want := punc + "[" + reset + "\n  " +
 		punc + "{" + reset + "\n    " +
@@ -703,8 +705,8 @@ func TestEncode_Punc_GranularOverride(t *testing.T) {
 
 	got := puncEncode(t, clrs, v)
 
-	key := func(s string) string { return "\"" + s + "\"" + reset }
-	val := func(s string) string { return s + reset }
+	key := func(s string) string { return "\"" + s + "\"" }
+	val := func(s string) string { return s }
 	// Brackets use the granular color; braces, comma and colon fall back to Punc.
 	want := brackets + "[" + reset + "\n  " +
 		punc + "{" + reset + "\n    " +
@@ -740,8 +742,8 @@ func TestEncode_Punc_AllGranular(t *testing.T) {
 
 	got := puncEncode(t, clrs, v)
 
-	key := func(s string) string { return "\"" + s + "\"" + reset }
-	val := func(s string) string { return s + reset }
+	key := func(s string) string { return "\"" + s + "\"" }
+	val := func(s string) string { return s }
 	want := brackets + "[" + reset + "\n  " +
 		braces + "{" + reset + "\n    " +
 		key("a") + colon + ":" + reset + " " + val("1") + comma + "," + reset + "\n    " +
@@ -1036,5 +1038,80 @@ func TestEncode_MapStringRawMessage_InvalidValue(t *testing.T) {
 				require.Equal(t, want, got)
 			})
 		}
+	}
+}
+
+// emptyColorValue exercises every token type the colored walk emits: null,
+// bool, number, string, key, bytes, time, TextMarshaler, RawMessage and all
+// four punctuation classes.
+var emptyColorValue = map[string]interface{}{
+	"null":   nil,
+	"bool":   true,
+	"int":    42,
+	"float":  1.5,
+	"str":    "s",
+	"bytes":  []byte("b"),
+	"time":   time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC),
+	"tm":     TextMarshaler{Text: "t"},
+	"raw":    jsoncolor.RawMessage(`{"k":[1,"v",null]}`),
+	"nested": []interface{}{1, "x", map[string]interface{}{"y": false}},
+}
+
+func encodeWith(t *testing.T, clrs *jsoncolor.Colors, indent bool, v interface{}) string {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	enc := jsoncolor.NewEncoder(buf)
+	enc.SetSortMapKeys(true)
+	enc.SetColors(clrs)
+	if indent {
+		enc.SetIndent("", "  ")
+	}
+	require.NoError(t, enc.Encode(v))
+	return buf.String()
+}
+
+// TestEncode_EmptyColors_NoReset verifies the documented contract that an
+// empty Color results in no colorization: a non-nil but empty palette must
+// produce output byte-identical to a nil palette, with no stray ANSI reset
+// after any token. See issue #54.
+func TestEncode_EmptyColors_NoReset(t *testing.T) {
+	for _, indent := range []bool{false, true} {
+		t.Run(fmt.Sprintf("indent=%v", indent), func(t *testing.T) {
+			want := encodeWith(t, nil, indent, emptyColorValue)
+			got := encodeWith(t, &jsoncolor.Colors{}, indent, emptyColorValue)
+			require.Equal(t, want, got)
+			require.NotContains(t, got, "\x1b[")
+		})
+	}
+}
+
+// TestEncode_PartialColors_OnlySetFieldsEmit verifies that a palette with a
+// single field set colors exactly that token type and leaves every other
+// token bare, with no reset anywhere else.
+func TestEncode_PartialColors_OnlySetFieldsEmit(t *testing.T) {
+	const (
+		green = "\x1b[32m"
+		reset = "\x1b[0m"
+	)
+	clrs := &jsoncolor.Colors{String: jsoncolor.Color(green)}
+	got := encodeWith(t, clrs, false, emptyColorValue)
+
+	// Strip the string coloring and the result must equal the plain output.
+	plain := strings.ReplaceAll(strings.ReplaceAll(got, green, ""), reset, "")
+	require.Equal(t, encodeWith(t, nil, false, emptyColorValue), plain)
+
+	// Every reset must be preceded by a green-colored string token, so the
+	// counts match and there are no bare resets.
+	require.Equal(t, strings.Count(got, green), strings.Count(got, reset))
+	require.Equal(t, 4, strings.Count(got, green), "str, tm (falls back to String), nested x, and v inside raw")
+}
+
+// TestEncode_DefaultColors_NoPuncReset verifies that DefaultColors, whose
+// Punc is intentionally empty, emits no reset after punctuation.
+func TestEncode_DefaultColors_NoPuncReset(t *testing.T) {
+	const reset = "\x1b[0m"
+	got := encodeWith(t, jsoncolor.DefaultColors(), false, map[string]interface{}{"a": 1, "b": []interface{}{true}})
+	for _, punc := range []string{"{", "}", "[", "]", ",", ":"} {
+		require.NotContains(t, got, punc+reset, "bare reset after %q in %q", punc, got)
 	}
 }


### PR DESCRIPTION
## Summary

Every colored emit site appended `\x1b[0m` unconditionally once the palette
pointer was non-nil, even when the `Color` selected for the token was empty. A
caller passing `&Colors{}` got a bare reset after every token, and
`DefaultColors()`, whose `Punc` is intentionally empty, emitted a stray reset
after every punctuation mark. The `Color` doc comment and the README both
promise that the zero value results in no colorization.

```
&Colors{} before: {\x1b[0m"a"\x1b[0m:\x1b[0m1\x1b[0m}\x1b[0m
&Colors{} after:  {"a":1}
```

Each of the fifteen emit sites now checks the selected color before writing
anything: an empty color takes the same plain path as a nil palette, skipping
both the prefix and the reset. The sites are the five append helpers on
`Colors`, and the float, number, key, string, bytes, time, struct-key,
RawMessage-scalar and TextMarshaler sites in the encoder. The nil-palette fast
paths are untouched.

Tests: an empty palette is byte-identical to a nil palette across every token
type, compact and indented; a palette with only `String` set colors exactly
the string tokens and nothing else; `DefaultColors()` emits no reset after
punctuation. The three punctuation tests from #42, which asserted the bare
reset after uncolored keys and values, are updated. All seven failed before
the fix.

## Output size

On a sample value through `DefaultColors()`, output shrinks from 579 to 431
bytes compact and from 706 to 558 bytes indented. Every removed byte was a
stray reset.

## Cost

`BenchmarkEncode` is confounded here: the harness's `bytes.Buffer` doubling
lands on different sides of a power-of-two boundary as output length changes,
so its two colored rows move in opposite directions on B/op with identical
allocation counts. A pre-sized micro-benchmark of `Append` isolates the change
(M1 Max, n=8, benchstat):

| palette | path | vs master |
|---|---|---|
| `DefaultColors()` (empty `Punc`) | compact | -10.4% |
| `DefaultColors()` (empty `Punc`) | indented | -10.3% |
| fully populated | compact | no significant change |
| fully populated | indented | +1.2% |

The default palette gets faster because Go compiles a variable-length append
into a runtime memmove call even for zero bytes, so on `master` every
punctuation mark paid that call to append the empty `Punc`. Checking the
color first skips it. A fully populated palette pays only the branch.

The first commit guarded only the reset and measured +7.7% on the default
palette; the second commit hoists the check and is what is described above.

## Compatibility

Byte-level change for anyone capturing colored output from a partially
populated palette, including `DefaultColors()`. On a terminal a bare reset
renders nothing, so there is no visible change.

Closes #54

## Checklist

- [x] Tests added or updated (regression test for bug fixes)
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] CHANGELOG entry added to `README.md` under the current version heading. v0.9.1 is already tagged, so this belongs under the next version heading when that is created at release time.
