### PR TITLE
Fix nil []byte double reset and trusted RawMessage depth leak

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -1535,7 +1535,7 @@ func (e encoder) appendRawMessageTokens(b, s []byte) ([]byte, error) {
 	if err == nil && len(stack) > 0 {
 		// Input ended inside a container. The tokenizer reports no error
 		// for that, but the message is malformed all the same.
-		err = syntaxError(s[len(s):], "unexpected end of JSON input")
+		err = unexpectedEOF(s[len(s):])
 	}
 
 	if err != nil {

--- a/encode.go
+++ b/encode.go
@@ -1472,6 +1472,16 @@ type rawFrame struct {
 func (e encoder) appendRawMessageTokens(b, s []byte) ([]byte, error) {
 	start := len(b)
 
+	// A malformed message can end with container frames still pushed.
+	// Record the depth so the error return can restore it: when the
+	// message is trusted, encodeRawMessage swallows the error and emits the
+	// bytes verbatim, so the reset-on-error in appendInternal never runs.
+	// See issue #66.
+	var depth int
+	if e.indentr != nil {
+		depth = e.indentr.depth
+	}
+
 	stack := make([]rawFrame, 0, 8)
 
 	tok := NewTokenizer(s)
@@ -1521,8 +1531,18 @@ func (e encoder) appendRawMessageTokens(b, s []byte) ([]byte, error) {
 		}
 	}
 
-	if tok.Err != nil {
-		return b[:start], tok.Err
+	err := tok.Err
+	if err == nil && len(stack) > 0 {
+		// Input ended inside a container. The tokenizer reports no error
+		// for that, but the message is malformed all the same.
+		err = syntaxError(s[len(s):], "unexpected end of JSON input")
+	}
+
+	if err != nil {
+		if e.indentr != nil {
+			e.indentr.depth = depth
+		}
+		return b[:start], err
 	}
 
 	return b, nil

--- a/encode.go
+++ b/encode.go
@@ -336,6 +336,13 @@ func (e encoder) encodeToString(b []byte, p unsafe.Pointer, encode encodeFunc) (
 }
 
 func (e encoder) encodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
+	// A nil slice renders as null, which is a null token: color it with
+	// Null alone rather than nesting it inside the Bytes color. See
+	// issue #67.
+	if *(*[]byte)(p) == nil {
+		return e.clrs.appendNull(b), nil
+	}
+
 	if e.clrs == nil || len(e.clrs.Bytes) == 0 {
 		return e.doEncodeBytes(b, p)
 	}

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -1115,3 +1115,22 @@ func TestEncode_DefaultColors_NoPuncReset(t *testing.T) {
 		require.NotContains(t, got, punc+reset, "bare reset after %q in %q", punc, got)
 	}
 }
+
+// TestEncode_NilBytes_SingleColor verifies that a nil []byte is a single null
+// token colored by Colors.Null alone, and a non-nil []byte a single bytes
+// token colored by Colors.Bytes alone, with exactly one reset each.
+func TestEncode_NilBytes_SingleColor(t *testing.T) {
+	const reset = "\x1b[0m"
+	clrs := &jsoncolor.Colors{Bytes: jsoncolor.Color("B"), Null: jsoncolor.Color("N")}
+
+	buf := &bytes.Buffer{}
+	enc := jsoncolor.NewEncoder(buf)
+	enc.SetColors(clrs)
+
+	require.NoError(t, enc.Encode(struct{ B []byte }{}))
+	require.Equal(t, `{"B":Nnull`+reset+"}\n", buf.String())
+
+	buf.Reset()
+	require.NoError(t, enc.Encode(struct{ B []byte }{B: []byte("a")}))
+	require.Equal(t, `{"B":B"YQ=="`+reset+"}\n", buf.String())
+}

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -1116,6 +1116,44 @@ func TestEncode_DefaultColors_NoPuncReset(t *testing.T) {
 	}
 }
 
+// rawMarshaler implements json.Marshaler with a caller-supplied payload, so
+// malformed output can be pushed through the Marshaler re-encoding path.
+type rawMarshaler struct{ raw string }
+
+func (m rawMarshaler) MarshalJSON() ([]byte, error) { return []byte(m.raw), nil }
+
+// TestEncode_TrustedMalformedRawMessage_NoDepthLeak verifies that a trusted
+// RawMessage which is not well-formed JSON, emitted verbatim per the
+// TrustRawMessage contract, does not leave the Encoder's indenter at a stale
+// depth for the next Encode.
+func TestEncode_TrustedMalformedRawMessage_NoDepthLeak(t *testing.T) {
+	malformed := []interface{}{
+		map[string]interface{}{"a": jsoncolor.RawMessage(`[1,2`), "b": 1},
+		map[string]interface{}{"a": jsoncolor.RawMessage(`{"x":[1,@]}`)},
+		jsoncolor.RawMessage(`{"k":{"n":[`),
+		[]interface{}{rawMarshaler{raw: `[[1,`}},
+	}
+
+	wantBuf := &bytes.Buffer{}
+	stdEnc := stdjson.NewEncoder(wantBuf)
+	stdEnc.SetIndent("", "  ")
+	require.NoError(t, stdEnc.Encode(map[string]int{"z": 1}))
+
+	for i, bad := range malformed {
+		t.Run(fmt.Sprintf("%d_%T", i, bad), func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			enc := jsoncolor.NewEncoder(buf)
+			enc.SetIndent("", "  ")
+			enc.SetTrustRawMessage(true)
+			require.NoError(t, enc.Encode(bad), "trusted messages are emitted without error")
+
+			buf.Reset()
+			require.NoError(t, enc.Encode(map[string]int{"z": 1}))
+			require.Equal(t, wantBuf.String(), buf.String())
+		})
+	}
+}
+
 // TestEncode_NilBytes_SingleColor verifies that a nil []byte is a single null
 // token colored by Colors.Null alone, and a non-nil []byte a single bytes
 // token colored by Colors.Bytes alone, with exactly one reset each.


### PR DESCRIPTION
## Summary

Two pre-existing bugs surfaced by the pre-release review of v0.9.2, both present
on v0.9.1, one commit each.

**#67, nil `[]byte` emits two prefixes and two resets.** `encodeBytes` applied
the `Bytes` color and then delegated to `doEncodeBytes`, which renders a nil
slice as `null` through `appendNull`, adding the `Null` prefix and its own reset
inside the `Bytes` wrapper. With `DefaultColors()` every zero-valued `[]byte`
field emitted `\x1b[2m\x1b[2mnull\x1b[0m\x1b[0m`. The nil check now runs before
the `Bytes` prefix, so a nil slice is a null token colored by `Null` alone and a
non-nil one a bytes token colored by `Bytes` alone.

**#66, trusted malformed `RawMessage` leaks indenter depth.** With
`SetTrustRawMessage(true)`, a malformed message is emitted verbatim without an
error, per the trust contract, but the tokenizer exited with container frames
still pushed and the verbatim fallback swallowed the error, so the
reset-on-error from #61 never ran and every later `Encode` on the same
`Encoder` was over-indented. A truncated message such as `[1,2` was worse: it
ran out of input with containers open and no tokenizer error at all, so it took
the success return. The tokenizer now records the depth on entry, treats end of
input inside a container as a syntax error, and restores the depth on the error
return. Untrusted messages are unaffected, since `parseValue` validates them
first; trusted ones still emit verbatim without error. The `json.Marshaler`
path, which re-encodes output as a `RawMessage`, is covered by the test.

Each commit carries its own regression test, and each was verified to pass in
isolation.

Closes #66
Closes #67

## Checklist

- [x] Tests added or updated (regression test for bug fixes)
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] CHANGELOG entry added to `README.md` under the current version heading. The v0.9.2 entry is pending on a local commit and will gain bullets for both once this lands.
