### PR TITLE
Consolidate the colorless fast paths and drop the forceSlow test plumbing

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -737,7 +737,7 @@ func stringify(f *reflect.StructField, c codec) codec {
 func encodeString(s string, flags AppendFlags) string {
 	b := make([]byte, 0, len(s)+2)
 	e := encoder{flags: flags}
-	b, _ = e.doEncodeString(b, unsafe.Pointer(&s))
+	b = e.doEncodeString(b, unsafe.Pointer(&s))
 	return *(*string)(unsafe.Pointer(&b))
 }
 

--- a/codec.go
+++ b/codec.go
@@ -24,11 +24,6 @@ type encoder struct {
 	flags   AppendFlags
 	clrs    *Colors
 	indentr *Indenter
-	// forceSlow disables encode-time fast paths so the colorless walk
-	// matches the colorized walk byte-for-byte. It exists for parity
-	// testing only and is never set in production paths; see
-	// appendInternal in json.go.
-	forceSlow bool
 }
 type decoder struct{ flags ParseFlags }
 

--- a/encode.go
+++ b/encode.go
@@ -1598,7 +1598,6 @@ func NewIndenter(prefix, indent string) *Indenter {
 	}
 }
 
-// push increases the indentation level.
 // enabled reports whether in produces indentation: a nil *Indenter and an
 // Indenter constructed with an empty prefix and indent are both disabled.
 // Every dispatcher that routes into an *Indented fast path, and every
@@ -1607,6 +1606,7 @@ func (in *Indenter) enabled() bool {
 	return in != nil && !in.disabled
 }
 
+// push increases the indentation level.
 func (in *Indenter) push() {
 	if in != nil {
 		in.depth++
@@ -1640,12 +1640,10 @@ func (in *Indenter) appendIndent(b []byte) []byte {
 	return in.appendIndentFast(b)
 }
 
-// appendIndentFast writes indentation to b assuming the receiver is
-// non-nil and not disabled. Callers must verify those preconditions; the
-// colorless fast paths do so once per container, then call this directly
-// to skip the per-token nil/disabled check.
-// appendIndentFast appends the prefix and depth indentation without any
-// nil or disabled check. Callers must only reach it when in.enabled().
+// appendIndentFast writes indentation to b without any nil or disabled
+// check. Callers must only reach it when in.enabled(); the colorless fast
+// paths verify that once per container, then call this directly to skip
+// the per-token check.
 func (in *Indenter) appendIndentFast(b []byte) []byte {
 	b = append(b, in.prefix...)
 	for i := 0; i < in.depth; i++ {

--- a/encode.go
+++ b/encode.go
@@ -635,21 +635,15 @@ var mapslicePool = sync.Pool{
 	New: func() interface{} { return new(mapslice) },
 }
 
-// getMapslice returns a pooled mapslice with room for n elements.
-func getMapslice(n int) *mapslice {
-	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
-	if cap(s.elements) < n {
-		s.elements = make([]element, 0, align(10, uintptr(n)))
-	}
-	return s
+// grow replaces the element buffer with one that has room for n elements.
+func (m *mapslice) grow(n int) {
+	m.elements = make([]element, 0, align(10, uintptr(n)))
 }
 
 // release clears the elements, so the pool holds no references, and
-// returns s to the pool.
+// returns m to the pool.
 func (m *mapslice) release() {
-	for i := range m.elements {
-		m.elements[i] = element{}
-	}
+	clear(m.elements)
 	m.elements = m.elements[:0]
 	mapslicePool.Put(m)
 }
@@ -707,7 +701,10 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 		return b, nil
 	}
 
-	s := getMapslice(len(m))
+	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
+	if cap(s.elements) < len(m) {
+		s.grow(len(m))
+	}
 	for key, val := range m {
 		s.elements = append(s.elements, element{key: key, val: val})
 	}
@@ -800,7 +797,10 @@ func (e encoder) encodeMapStringInterfaceFast(b []byte, p unsafe.Pointer) ([]byt
 			n++
 		}
 	} else {
-		s := getMapslice(len(m))
+		s := mapslicePool.Get().(*mapslice) //nolint:errcheck
+		if cap(s.elements) < len(m) {
+			s.grow(len(m))
+		}
 		for key, v := range m {
 			s.elements = append(s.elements, element{key: key, val: v})
 		}
@@ -889,7 +889,10 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 		return b, nil
 	}
 
-	s := getMapslice(len(m))
+	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
+	if cap(s.elements) < len(m) {
+		s.grow(len(m))
+	}
 	for key, raw := range m {
 		s.elements = append(s.elements, element{key: key, raw: raw})
 	}
@@ -964,7 +967,10 @@ func (e encoder) encodeMapStringRawMessageFast(b []byte, p unsafe.Pointer) ([]by
 			n++
 		}
 	} else {
-		s := getMapslice(len(m))
+		s := mapslicePool.Get().(*mapslice) //nolint:errcheck
+		if cap(s.elements) < len(m) {
+			s.grow(len(m))
+		}
 		for key, v := range m {
 			s.elements = append(s.elements, element{key: key, raw: v})
 		}

--- a/encode.go
+++ b/encode.go
@@ -515,10 +515,7 @@ func (e encoder) encodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 
 func (e encoder) encodeMap(b []byte, p unsafe.Pointer, t reflect.Type, encodeKey, encodeValue encodeFunc, sortKeys sortFunc) ([]byte, error) {
 	if e.clrs == nil {
-		if !e.indentr.enabled() {
-			return e.encodeMapPlain(b, p, t, encodeKey, encodeValue, sortKeys)
-		}
-		return e.encodeMapIndented(b, p, t, encodeKey, encodeValue, sortKeys)
+		return e.encodeMapFast(b, p, t, encodeKey, encodeValue, sortKeys)
 	}
 
 	m := reflect.NewAt(t, p).Elem()
@@ -569,10 +566,12 @@ func (e encoder) encodeMap(b []byte, p unsafe.Pointer, t reflect.Type, encodeKey
 	return b, nil
 }
 
-func (e encoder) encodeMapPlain(b []byte, p unsafe.Pointer, t reflect.Type, encodeKey, encodeValue encodeFunc, sortKeys sortFunc) ([]byte, error) {
+// encodeMapFast is the colorless path for encodeMap. The caller must have
+// checked that e.clrs is nil; indentation is decided here once.
+func (e encoder) encodeMapFast(b []byte, p unsafe.Pointer, t reflect.Type, encodeKey, encodeValue encodeFunc, sortKeys sortFunc) ([]byte, error) {
 	m := reflect.NewAt(t, p).Elem()
 	if m.IsNil() {
-		return append(b, "null"...), nil
+		return e.clrs.appendNull(b), nil
 	}
 
 	keys := m.MapKeys()
@@ -580,62 +579,47 @@ func (e encoder) encodeMapPlain(b []byte, p unsafe.Pointer, t reflect.Type, enco
 		sortKeys(keys)
 	}
 
+	ind := e.indentr.enabled()
 	start := len(b)
+
 	b = append(b, '{')
+	if ind {
+		e.indentr.depth++
+	}
+
 	for i := range keys {
 		k := keys[i]
 		v := m.MapIndex(k)
+
 		if i != 0 {
 			b = append(b, ',')
 		}
+		if ind {
+			b = append(b, '\n')
+			b = e.indentr.appendIndentFast(b)
+		}
+
 		var err error
 		if b, err = encodeKey(e, b, (*iface)(unsafe.Pointer(&k)).ptr); err != nil {
 			return b[:start], err
 		}
 		b = append(b, ':')
+		if ind {
+			b = append(b, ' ')
+		}
 		if b, err = encodeValue(e, b, (*iface)(unsafe.Pointer(&v)).ptr); err != nil {
 			return b[:start], err
 		}
 	}
-	return append(b, '}'), nil
-}
 
-func (e encoder) encodeMapIndented(b []byte, p unsafe.Pointer, t reflect.Type, encodeKey, encodeValue encodeFunc, sortKeys sortFunc) ([]byte, error) {
-	m := reflect.NewAt(t, p).Elem()
-	if m.IsNil() {
-		return append(b, "null"...), nil
-	}
-
-	keys := m.MapKeys()
-	if sortKeys != nil && (e.flags&SortMapKeys) != 0 {
-		sortKeys(keys)
-	}
-
-	start := len(b)
-	b = append(b, '{')
-	if len(keys) != 0 {
-		b = append(b, '\n')
-		e.indentr.depth++
-		for i := range keys {
-			k := keys[i]
-			v := m.MapIndex(k)
-			if i != 0 {
-				b = append(b, ',', '\n')
-			}
-			b = e.indentr.appendIndentFast(b)
-			var err error
-			if b, err = encodeKey(e, b, (*iface)(unsafe.Pointer(&k)).ptr); err != nil {
-				return b[:start], err
-			}
-			b = append(b, ':', ' ')
-			if b, err = encodeValue(e, b, (*iface)(unsafe.Pointer(&v)).ptr); err != nil {
-				return b[:start], err
-			}
-		}
-		b = append(b, '\n')
+	if ind {
 		e.indentr.depth--
-		b = e.indentr.appendIndentFast(b)
+		if len(keys) > 0 {
+			b = append(b, '\n')
+			b = e.indentr.appendIndentFast(b)
+		}
 	}
+
 	return append(b, '}'), nil
 }
 
@@ -657,12 +641,28 @@ var mapslicePool = sync.Pool{
 	New: func() interface{} { return new(mapslice) },
 }
 
+// getMapslice returns a pooled mapslice with room for n elements.
+func getMapslice(n int) *mapslice {
+	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
+	if cap(s.elements) < n {
+		s.elements = make([]element, 0, align(10, uintptr(n)))
+	}
+	return s
+}
+
+// release clears the elements, so the pool holds no references, and
+// returns s to the pool.
+func (m *mapslice) release() {
+	for i := range m.elements {
+		m.elements[i] = element{}
+	}
+	m.elements = m.elements[:0]
+	mapslicePool.Put(m)
+}
+
 func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
 	if e.clrs == nil {
-		if !e.indentr.enabled() {
-			return e.encodeMapStringInterfacePlain(b, p)
-		}
-		return e.encodeMapStringInterfaceIndented(b, p)
+		return e.encodeMapStringInterfaceFast(b, p)
 	}
 
 	m := *(*map[string]interface{})(p)
@@ -716,10 +716,7 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 		return b, nil
 	}
 
-	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
-	if cap(s.elements) < len(m) {
-		s.elements = make([]element, 0, align(10, uintptr(len(m))))
-	}
+	s := getMapslice(len(m))
 	for key, val := range m {
 		s.elements = append(s.elements, element{key: key, val: val})
 	}
@@ -755,12 +752,7 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 		b = e.indentr.appendIndent(b)
 	}
 
-	for i := range s.elements {
-		s.elements[i] = element{}
-	}
-
-	s.elements = s.elements[:0]
-	mapslicePool.Put(s)
+	s.release()
 
 	if err != nil {
 		return b[:start], err
@@ -770,154 +762,88 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 	return b, nil
 }
 
-func (e encoder) encodeMapStringInterfacePlain(b []byte, p unsafe.Pointer) ([]byte, error) {
-	m := *(*map[string]interface{})(p)
-	if m == nil {
-		return append(b, "null"...), nil
+// appendFastMember appends everything that precedes the i'th member's value
+// in an object on the colorless path: a comma when i > 0, a newline and
+// indentation when ind, the encoded key, a colon, and a space when ind.
+func (e encoder) appendFastMember(b []byte, i int, ind bool, key string) []byte {
+	if i != 0 {
+		b = append(b, ',')
 	}
-
-	start := len(b)
-
-	if (e.flags & SortMapKeys) == 0 {
-		b = append(b, '{')
-		i := 0
-		for k, v := range m {
-			if i != 0 {
-				b = append(b, ',')
-			}
-			var err error
-			if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
-				return b[:start], err
-			}
-			b = append(b, ':')
-			if b, err = Append(b, v, e.flags, nil, e.indentr); err != nil {
-				return b[:start], err
-			}
-			i++
-		}
-		return append(b, '}'), nil
+	if ind {
+		b = append(b, '\n')
+		b = e.indentr.appendIndentFast(b)
 	}
-
-	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
-	if cap(s.elements) < len(m) {
-		s.elements = make([]element, 0, align(10, uintptr(len(m))))
+	b, _ = e.encodeKey(b, unsafe.Pointer(&key))
+	b = append(b, ':')
+	if ind {
+		b = append(b, ' ')
 	}
-	for key, val := range m {
-		s.elements = append(s.elements, element{key: key, val: val})
-	}
-	sort.Sort(s)
-
-	var err error
-	b = append(b, '{')
-	for i := range s.elements {
-		elem := s.elements[i]
-		if i != 0 {
-			b = append(b, ',')
-		}
-		b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
-		b = append(b, ':')
-		if b, err = Append(b, elem.val, e.flags, nil, e.indentr); err != nil {
-			break
-		}
-	}
-
-	for i := range s.elements {
-		s.elements[i] = element{}
-	}
-	s.elements = s.elements[:0]
-	mapslicePool.Put(s)
-
-	if err != nil {
-		return b[:start], err
-	}
-	return append(b, '}'), nil
+	return b
 }
 
-func (e encoder) encodeMapStringInterfaceIndented(b []byte, p unsafe.Pointer) ([]byte, error) {
+// encodeMapStringInterfaceFast is the colorless path for encodeMapStringInterface. The caller must have checked
+// that e.clrs is nil; indentation is decided here once.
+func (e encoder) encodeMapStringInterfaceFast(b []byte, p unsafe.Pointer) ([]byte, error) {
 	m := *(*map[string]interface{})(p)
 	if m == nil {
-		return append(b, "null"...), nil
+		return e.clrs.appendNull(b), nil
 	}
 
+	ind := e.indentr.enabled()
 	start := len(b)
 
-	if (e.flags & SortMapKeys) == 0 {
-		b = append(b, '{')
-		if len(m) != 0 {
-			b = append(b, '\n')
-			e.indentr.depth++
-			i := 0
-			for k, v := range m {
-				if i != 0 {
-					b = append(b, ',', '\n')
-				}
-				b = e.indentr.appendIndentFast(b)
-				var err error
-				if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
-					return b[:start], err
-				}
-				b = append(b, ':', ' ')
-				if b, err = Append(b, v, e.flags, nil, e.indentr); err != nil {
-					return b[:start], err
-				}
-				i++
-			}
-			b = append(b, '\n')
-			e.indentr.depth--
-			b = e.indentr.appendIndentFast(b)
-		}
-		return append(b, '}'), nil
+	b = append(b, '{')
+	if ind {
+		e.indentr.depth++
 	}
-
-	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
-	if cap(s.elements) < len(m) {
-		s.elements = make([]element, 0, align(10, uintptr(len(m))))
-	}
-	for key, val := range m {
-		s.elements = append(s.elements, element{key: key, val: val})
-	}
-	sort.Sort(s)
 
 	var err error
-	b = append(b, '{')
-	if len(s.elements) > 0 {
-		b = append(b, '\n')
-		e.indentr.depth++
+	n := 0
+
+	if (e.flags & SortMapKeys) == 0 {
+		for k, v := range m {
+			b = e.appendFastMember(b, n, ind, k)
+			if b, err = Append(b, v, e.flags, nil, e.indentr); err != nil {
+				break
+			}
+			n++
+		}
+	} else {
+		s := getMapslice(len(m))
+		for key, v := range m {
+			s.elements = append(s.elements, element{key: key, val: v})
+		}
+		sort.Sort(s)
+
 		for i := range s.elements {
 			elem := s.elements[i]
-			if i != 0 {
-				b = append(b, ',', '\n')
-			}
-			b = e.indentr.appendIndentFast(b)
-			b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
-			b = append(b, ':', ' ')
+			b = e.appendFastMember(b, n, ind, elem.key)
 			if b, err = Append(b, elem.val, e.flags, nil, e.indentr); err != nil {
 				break
 			}
+			n++
 		}
-		b = append(b, '\n')
-		e.indentr.depth--
-		b = e.indentr.appendIndentFast(b)
+		s.release()
 	}
-
-	for i := range s.elements {
-		s.elements[i] = element{}
-	}
-	s.elements = s.elements[:0]
-	mapslicePool.Put(s)
 
 	if err != nil {
 		return b[:start], err
 	}
+
+	if ind {
+		e.indentr.depth--
+		if n > 0 {
+			b = append(b, '\n')
+			b = e.indentr.appendIndentFast(b)
+		}
+	}
+
 	return append(b, '}'), nil
 }
 
 func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 	if e.clrs == nil {
-		if !e.indentr.enabled() {
-			return e.encodeMapStringRawMessagePlain(b, p)
-		}
-		return e.encodeMapStringRawMessageIndented(b, p)
+		return e.encodeMapStringRawMessageFast(b, p)
 	}
 
 	m := *(*map[string]RawMessage)(p)
@@ -972,10 +898,7 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 		return b, nil
 	}
 
-	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
-	if cap(s.elements) < len(m) {
-		s.elements = make([]element, 0, align(10, uintptr(len(m))))
-	}
+	s := getMapslice(len(m))
 	for key, raw := range m {
 		s.elements = append(s.elements, element{key: key, raw: raw})
 	}
@@ -1012,12 +935,7 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 		b = e.indentr.appendIndent(b)
 	}
 
-	for i := range s.elements {
-		s.elements[i] = element{}
-	}
-
-	s.elements = s.elements[:0]
-	mapslicePool.Put(s)
+	s.release()
 
 	if err != nil {
 		return b[:start], err
@@ -1027,147 +945,63 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 	return b, nil
 }
 
-func (e encoder) encodeMapStringRawMessagePlain(b []byte, p unsafe.Pointer) ([]byte, error) {
+// encodeMapStringRawMessageFast is the colorless path for encodeMapStringRawMessage. The caller must have checked
+// that e.clrs is nil; indentation is decided here once.
+func (e encoder) encodeMapStringRawMessageFast(b []byte, p unsafe.Pointer) ([]byte, error) {
 	m := *(*map[string]RawMessage)(p)
 	if m == nil {
-		return append(b, "null"...), nil
+		return e.clrs.appendNull(b), nil
 	}
 
+	ind := e.indentr.enabled()
 	start := len(b)
 
-	if (e.flags & SortMapKeys) == 0 {
-		b = append(b, '{')
-		i := 0
-		for k := range m {
-			if i != 0 {
-				b = append(b, ',')
-			}
-			var err error
-			if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
-				return b[:start], err
-			}
-			b = append(b, ':')
-			v := m[k]
-			if b, err = e.encodeRawMessage(b, unsafe.Pointer(&v)); err != nil {
-				return b[:start], err
-			}
-			i++
-		}
-		return append(b, '}'), nil
-	}
-
-	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
-	if cap(s.elements) < len(m) {
-		s.elements = make([]element, 0, align(10, uintptr(len(m))))
-	}
-	for key, raw := range m {
-		s.elements = append(s.elements, element{key: key, raw: raw})
-	}
-	sort.Sort(s)
-
-	var err error
 	b = append(b, '{')
-	for i := range s.elements {
-		elem := s.elements[i]
-		if i != 0 {
-			b = append(b, ',')
-		}
-		b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
-		b = append(b, ':')
-		if b, err = e.encodeRawMessage(b, unsafe.Pointer(&elem.raw)); err != nil {
-			break
-		}
-	}
-
-	for i := range s.elements {
-		s.elements[i] = element{}
-	}
-	s.elements = s.elements[:0]
-	mapslicePool.Put(s)
-
-	if err != nil {
-		return b[:start], err
-	}
-	return append(b, '}'), nil
-}
-
-func (e encoder) encodeMapStringRawMessageIndented(b []byte, p unsafe.Pointer) ([]byte, error) {
-	m := *(*map[string]RawMessage)(p)
-	if m == nil {
-		return append(b, "null"...), nil
-	}
-
-	start := len(b)
-
-	if (e.flags & SortMapKeys) == 0 {
-		b = append(b, '{')
-		if len(m) != 0 {
-			b = append(b, '\n')
-			e.indentr.depth++
-			i := 0
-			for k := range m {
-				if i != 0 {
-					b = append(b, ',', '\n')
-				}
-				b = e.indentr.appendIndentFast(b)
-				var err error
-				if b, err = e.encodeKey(b, unsafe.Pointer(&k)); err != nil {
-					return b[:start], err
-				}
-				b = append(b, ':', ' ')
-				v := m[k]
-				if b, err = e.encodeRawMessage(b, unsafe.Pointer(&v)); err != nil {
-					return b[:start], err
-				}
-				i++
-			}
-			b = append(b, '\n')
-			e.indentr.depth--
-			b = e.indentr.appendIndentFast(b)
-		}
-		return append(b, '}'), nil
-	}
-
-	s := mapslicePool.Get().(*mapslice) //nolint:errcheck
-	if cap(s.elements) < len(m) {
-		s.elements = make([]element, 0, align(10, uintptr(len(m))))
-	}
-	for key, raw := range m {
-		s.elements = append(s.elements, element{key: key, raw: raw})
-	}
-	sort.Sort(s)
-
-	var err error
-	b = append(b, '{')
-	if len(s.elements) > 0 {
-		b = append(b, '\n')
+	if ind {
 		e.indentr.depth++
+	}
+
+	var err error
+	n := 0
+
+	if (e.flags & SortMapKeys) == 0 {
+		for k, v := range m {
+			b = e.appendFastMember(b, n, ind, k)
+			if b, err = e.encodeRawMessage(b, unsafe.Pointer(&v)); err != nil {
+				break
+			}
+			n++
+		}
+	} else {
+		s := getMapslice(len(m))
+		for key, v := range m {
+			s.elements = append(s.elements, element{key: key, raw: v})
+		}
+		sort.Sort(s)
+
 		for i := range s.elements {
 			elem := s.elements[i]
-			if i != 0 {
-				b = append(b, ',', '\n')
-			}
-			b = e.indentr.appendIndentFast(b)
-			b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
-			b = append(b, ':', ' ')
+			b = e.appendFastMember(b, n, ind, elem.key)
 			if b, err = e.encodeRawMessage(b, unsafe.Pointer(&elem.raw)); err != nil {
 				break
 			}
+			n++
 		}
-		b = append(b, '\n')
-		e.indentr.depth--
-		b = e.indentr.appendIndentFast(b)
+		s.release()
 	}
-
-	for i := range s.elements {
-		s.elements[i] = element{}
-	}
-	s.elements = s.elements[:0]
-	mapslicePool.Put(s)
 
 	if err != nil {
 		return b[:start], err
 	}
+
+	if ind {
+		e.indentr.depth--
+		if n > 0 {
+			b = append(b, '\n')
+			b = e.indentr.appendIndentFast(b)
+		}
+	}
+
 	return append(b, '}'), nil
 }
 

--- a/encode.go
+++ b/encode.go
@@ -183,31 +183,36 @@ func (e encoder) encodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 	return b, nil
 }
 
+// encodeKey is the encodeFunc form of appendKey, installed as the key codec
+// for string-keyed maps.
 func (e encoder) encodeKey(b []byte, p unsafe.Pointer) ([]byte, error) {
+	return e.appendKey(b, *(*string)(p)), nil
+}
+
+// appendKey appends the object key k, colored by Colors.Key when set.
+// Encoding a string cannot fail, so there is no error to return.
+func (e encoder) appendKey(b []byte, k string) []byte {
 	if e.clrs == nil || len(e.clrs.Key) == 0 {
-		return e.doEncodeString(b, p)
+		return e.doEncodeString(b, unsafe.Pointer(&k))
 	}
 
 	b = append(b, e.clrs.Key...)
-	var err error
-	b, err = e.doEncodeString(b, p)
-	b = append(b, ansiReset...)
-	return b, err
+	b = e.doEncodeString(b, unsafe.Pointer(&k))
+	return append(b, ansiReset...)
 }
 
 func (e encoder) encodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
 	if e.clrs == nil || len(e.clrs.String) == 0 {
-		return e.doEncodeString(b, p)
+		return e.doEncodeString(b, p), nil
 	}
 
 	b = append(b, e.clrs.String...)
-	var err error
-	b, err = e.doEncodeString(b, p)
+	b = e.doEncodeString(b, p)
 	b = append(b, ansiReset...)
-	return b, err
+	return b, nil
 }
 
-func (e encoder) doEncodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
+func (e encoder) doEncodeString(b []byte, p unsafe.Pointer) []byte {
 	s := *(*string)(p)
 	i := 0
 	j := 0
@@ -304,7 +309,7 @@ func (e encoder) doEncodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	b = append(b, s[i:]...)
 	b = append(b, '"')
-	return b, nil
+	return b
 }
 
 func (e encoder) encodeToString(b []byte, p unsafe.Pointer, encode encodeFunc) ([]byte, error) {
@@ -318,9 +323,7 @@ func (e encoder) encodeToString(b []byte, p unsafe.Pointer, encode encodeFunc) (
 	j := len(b)
 	s := b[i:]
 
-	if b, err = e.doEncodeString(b, unsafe.Pointer(&s)); err != nil {
-		return b, err
-	}
+	b = e.doEncodeString(b, unsafe.Pointer(&s))
 
 	n := copy(b[i:], b[j:])
 	return b[:i+n], nil
@@ -683,10 +686,7 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 
 				b = e.indentr.appendIndent(b)
 
-				b, err = e.encodeKey(b, unsafe.Pointer(&k))
-				if err != nil {
-					return b[:start], err
-				}
+				b = e.appendKey(b, k)
 
 				b = e.clrs.appendPunc(b, ':')
 				b = e.indentr.appendByte(b, ' ')
@@ -729,7 +729,7 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 
 			b = e.indentr.appendIndent(b)
 
-			b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
+			b = e.appendKey(b, elem.key)
 			b = e.clrs.appendPunc(b, ':')
 			b = e.indentr.appendByte(b, ' ')
 
@@ -764,7 +764,7 @@ func (e encoder) appendFastMember(b []byte, i int, ind bool, key string) []byte 
 		b = append(b, '\n')
 		b = e.indentr.appendIndentFast(b)
 	}
-	b, _ = e.encodeKey(b, unsafe.Pointer(&key))
+	b = e.appendKey(b, key)
 	b = append(b, ':')
 	if ind {
 		b = append(b, ' ')
@@ -864,7 +864,7 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 
 				b = e.indentr.appendIndent(b)
 
-				b, _ = e.encodeKey(b, unsafe.Pointer(&k))
+				b = e.appendKey(b, k)
 
 				b = e.clrs.appendPunc(b, ':')
 				b = e.indentr.appendByte(b, ' ')
@@ -912,7 +912,7 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 			b = e.indentr.appendIndent(b)
 
 			elem := s.elements[i]
-			b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
+			b = e.appendKey(b, elem.key)
 			b = e.clrs.appendPunc(b, ':')
 			b = e.indentr.appendByte(b, ' ')
 
@@ -1488,18 +1488,18 @@ func (e encoder) encodeTextMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 	}
 
 	if e.clrs == nil {
-		return e.doEncodeString(b, unsafe.Pointer(&s))
+		return e.doEncodeString(b, unsafe.Pointer(&s)), nil
 	}
 
 	clr := e.clrs.textMarshalerColor()
 	if len(clr) == 0 {
-		return e.doEncodeString(b, unsafe.Pointer(&s))
+		return e.doEncodeString(b, unsafe.Pointer(&s)), nil
 	}
 
 	b = append(b, clr...)
-	b, err = e.doEncodeString(b, unsafe.Pointer(&s))
+	b = e.doEncodeString(b, unsafe.Pointer(&s))
 	b = append(b, ansiReset...)
-	return b, err
+	return b, nil
 }
 
 func appendCompactEscapeHTML(dst, src []byte) []byte {

--- a/encode.go
+++ b/encode.go
@@ -18,14 +18,14 @@ import (
 const hex = "0123456789abcdef"
 
 func (e encoder) encodeNull(b []byte, _ unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return append(b, "null"...), nil
 	}
 	return e.clrs.appendNull(b), nil
 }
 
 func (e encoder) encodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		if *(*bool)(p) {
 			return append(b, "true"...), nil
 		}
@@ -35,77 +35,77 @@ func (e encoder) encodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeInt(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendInt(b, int64(*(*int)(p)), 10), nil
 	}
 	return e.clrs.appendInt64(b, int64(*(*int)(p))), nil
 }
 
 func (e encoder) encodeInt8(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendInt(b, int64(*(*int8)(p)), 10), nil
 	}
 	return e.clrs.appendInt64(b, int64(*(*int8)(p))), nil
 }
 
 func (e encoder) encodeInt16(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendInt(b, int64(*(*int16)(p)), 10), nil
 	}
 	return e.clrs.appendInt64(b, int64(*(*int16)(p))), nil
 }
 
 func (e encoder) encodeInt32(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendInt(b, int64(*(*int32)(p)), 10), nil
 	}
 	return e.clrs.appendInt64(b, int64(*(*int32)(p))), nil
 }
 
 func (e encoder) encodeInt64(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendInt(b, *(*int64)(p), 10), nil
 	}
 	return e.clrs.appendInt64(b, *(*int64)(p)), nil
 }
 
 func (e encoder) encodeUint(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendUint(b, uint64(*(*uint)(p)), 10), nil
 	}
 	return e.clrs.appendUint64(b, uint64(*(*uint)(p))), nil
 }
 
 func (e encoder) encodeUintptr(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendUint(b, uint64(*(*uintptr)(p)), 10), nil
 	}
 	return e.clrs.appendUint64(b, uint64(*(*uintptr)(p))), nil
 }
 
 func (e encoder) encodeUint8(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendUint(b, uint64(*(*uint8)(p)), 10), nil
 	}
 	return e.clrs.appendUint64(b, uint64(*(*uint8)(p))), nil
 }
 
 func (e encoder) encodeUint16(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendUint(b, uint64(*(*uint16)(p)), 10), nil
 	}
 	return e.clrs.appendUint64(b, uint64(*(*uint16)(p))), nil
 }
 
 func (e encoder) encodeUint32(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendUint(b, uint64(*(*uint32)(p)), 10), nil
 	}
 	return e.clrs.appendUint64(b, uint64(*(*uint32)(p))), nil
 }
 
 func (e encoder) encodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendUint(b, *(*uint64)(p), 10), nil
 	}
 	return e.clrs.appendUint64(b, *(*uint64)(p)), nil
@@ -382,7 +382,7 @@ func (e encoder) encodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 	//  The stdlib encoder does not. It just outputs the int64 value.
 	//  We choose to follow the stdlib pattern, for fuller compatibility.
 
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		return strconv.AppendInt(b, int64(*(*time.Duration)(p)), 10), nil
 	}
 	b = e.clrs.appendInt64(b, int64(*(*time.Duration)(p)))
@@ -424,7 +424,7 @@ func (e encoder) encodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, _ reflect.Type, encode encodeFunc) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		if e.indentr == nil || e.indentr.disabled {
 			return e.encodeArrayPlain(b, p, n, size, encode)
 		}
@@ -514,7 +514,7 @@ func (e encoder) encodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 }
 
 func (e encoder) encodeMap(b []byte, p unsafe.Pointer, t reflect.Type, encodeKey, encodeValue encodeFunc, sortKeys sortFunc) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		if e.indentr == nil || e.indentr.disabled {
 			return e.encodeMapPlain(b, p, t, encodeKey, encodeValue, sortKeys)
 		}
@@ -658,7 +658,7 @@ var mapslicePool = sync.Pool{
 }
 
 func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		if e.indentr == nil || e.indentr.disabled {
 			return e.encodeMapStringInterfacePlain(b, p)
 		}
@@ -700,7 +700,7 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 				b = e.clrs.appendPunc(b, ':')
 				b = e.indentr.appendByte(b, ' ')
 
-				b, err = appendInternal(b, v, e.flags, e.clrs, e.indentr, e.forceSlow)
+				b, err = Append(b, v, e.flags, e.clrs, e.indentr)
 				if err != nil {
 					return b[:start], err
 				}
@@ -745,7 +745,7 @@ func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 			b = e.clrs.appendPunc(b, ':')
 			b = e.indentr.appendByte(b, ' ')
 
-			b, err = appendInternal(b, elem.val, e.flags, e.clrs, e.indentr, e.forceSlow)
+			b, err = Append(b, elem.val, e.flags, e.clrs, e.indentr)
 			if err != nil {
 				break
 			}
@@ -790,7 +790,7 @@ func (e encoder) encodeMapStringInterfacePlain(b []byte, p unsafe.Pointer) ([]by
 				return b[:start], err
 			}
 			b = append(b, ':')
-			if b, err = appendInternal(b, v, e.flags, nil, e.indentr, false); err != nil {
+			if b, err = Append(b, v, e.flags, nil, e.indentr); err != nil {
 				return b[:start], err
 			}
 			i++
@@ -816,7 +816,7 @@ func (e encoder) encodeMapStringInterfacePlain(b []byte, p unsafe.Pointer) ([]by
 		}
 		b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
 		b = append(b, ':')
-		if b, err = appendInternal(b, elem.val, e.flags, nil, e.indentr, false); err != nil {
+		if b, err = Append(b, elem.val, e.flags, nil, e.indentr); err != nil {
 			break
 		}
 	}
@@ -857,7 +857,7 @@ func (e encoder) encodeMapStringInterfaceIndented(b []byte, p unsafe.Pointer) ([
 					return b[:start], err
 				}
 				b = append(b, ':', ' ')
-				if b, err = appendInternal(b, v, e.flags, nil, e.indentr, false); err != nil {
+				if b, err = Append(b, v, e.flags, nil, e.indentr); err != nil {
 					return b[:start], err
 				}
 				i++
@@ -891,7 +891,7 @@ func (e encoder) encodeMapStringInterfaceIndented(b []byte, p unsafe.Pointer) ([
 			b = e.indentr.appendIndentFast(b)
 			b, _ = e.encodeKey(b, unsafe.Pointer(&elem.key))
 			b = append(b, ':', ' ')
-			if b, err = appendInternal(b, elem.val, e.flags, nil, e.indentr, false); err != nil {
+			if b, err = Append(b, elem.val, e.flags, nil, e.indentr); err != nil {
 				break
 			}
 		}
@@ -913,7 +913,7 @@ func (e encoder) encodeMapStringInterfaceIndented(b []byte, p unsafe.Pointer) ([
 }
 
 func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		if e.indentr == nil || e.indentr.disabled {
 			return e.encodeMapStringRawMessagePlain(b, p)
 		}
@@ -1172,7 +1172,7 @@ func (e encoder) encodeMapStringRawMessageIndented(b []byte, p unsafe.Pointer) (
 }
 
 func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byte, error) {
-	if e.clrs == nil && !e.forceSlow {
+	if e.clrs == nil {
 		if e.indentr == nil || e.indentr.disabled {
 			return e.encodeStructPlain(b, p, st)
 		}
@@ -1373,11 +1373,11 @@ func (e encoder) encodePointer(b []byte, p unsafe.Pointer, _ reflect.Type, encod
 }
 
 func (e encoder) encodeInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
-	return appendInternal(b, *(*interface{})(p), e.flags, e.clrs, e.indentr, e.forceSlow)
+	return Append(b, *(*interface{})(p), e.flags, e.clrs, e.indentr)
 }
 
 func (e encoder) encodeMaybeEmptyInterface(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
-	return appendInternal(b, reflect.NewAt(t, p).Elem().Interface(), e.flags, e.clrs, e.indentr, e.forceSlow)
+	return Append(b, reflect.NewAt(t, p).Elem().Interface(), e.flags, e.clrs, e.indentr)
 }
 
 func (e encoder) encodeUnsupportedTypeError(b []byte, _ unsafe.Pointer, t reflect.Type) ([]byte, error) {
@@ -1475,7 +1475,7 @@ func (e encoder) appendRawMessageTokens(b, s []byte) ([]byte, error) {
 	// A malformed message can end with container frames still pushed.
 	// Record the depth so the error return can restore it: when the
 	// message is trusted, encodeRawMessage swallows the error and emits the
-	// bytes verbatim, so the reset-on-error in appendInternal never runs.
+	// bytes verbatim, so the reset-on-error in Append never runs.
 	// See issue #66.
 	var depth int
 	if e.indentr != nil {
@@ -1639,7 +1639,7 @@ func (e encoder) encodeJSONMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 	}
 
 	// We effectively delegate to the encodeRawMessage method.
-	return appendInternal(b, RawMessage(j), e.flags, e.clrs, e.indentr, e.forceSlow)
+	return Append(b, RawMessage(j), e.flags, e.clrs, e.indentr)
 }
 
 func (e encoder) encodeTextMarshaler(b []byte, p unsafe.Pointer, t reflect.Type, pointer bool) ([]byte, error) {

--- a/encode.go
+++ b/encode.go
@@ -425,7 +425,7 @@ func (e encoder) encodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 func (e encoder) encodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, _ reflect.Type, encode encodeFunc) ([]byte, error) {
 	if e.clrs == nil {
-		if e.indentr == nil || e.indentr.disabled {
+		if !e.indentr.enabled() {
 			return e.encodeArrayPlain(b, p, n, size, encode)
 		}
 		return e.encodeArrayIndented(b, p, n, size, encode)
@@ -515,7 +515,7 @@ func (e encoder) encodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 
 func (e encoder) encodeMap(b []byte, p unsafe.Pointer, t reflect.Type, encodeKey, encodeValue encodeFunc, sortKeys sortFunc) ([]byte, error) {
 	if e.clrs == nil {
-		if e.indentr == nil || e.indentr.disabled {
+		if !e.indentr.enabled() {
 			return e.encodeMapPlain(b, p, t, encodeKey, encodeValue, sortKeys)
 		}
 		return e.encodeMapIndented(b, p, t, encodeKey, encodeValue, sortKeys)
@@ -659,7 +659,7 @@ var mapslicePool = sync.Pool{
 
 func (e encoder) encodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
 	if e.clrs == nil {
-		if e.indentr == nil || e.indentr.disabled {
+		if !e.indentr.enabled() {
 			return e.encodeMapStringInterfacePlain(b, p)
 		}
 		return e.encodeMapStringInterfaceIndented(b, p)
@@ -914,7 +914,7 @@ func (e encoder) encodeMapStringInterfaceIndented(b []byte, p unsafe.Pointer) ([
 
 func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 	if e.clrs == nil {
-		if e.indentr == nil || e.indentr.disabled {
+		if !e.indentr.enabled() {
 			return e.encodeMapStringRawMessagePlain(b, p)
 		}
 		return e.encodeMapStringRawMessageIndented(b, p)
@@ -1173,7 +1173,7 @@ func (e encoder) encodeMapStringRawMessageIndented(b []byte, p unsafe.Pointer) (
 
 func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byte, error) {
 	if e.clrs == nil {
-		if e.indentr == nil || e.indentr.disabled {
+		if !e.indentr.enabled() {
 			return e.encodeStructPlain(b, p, st)
 		}
 		return e.encodeStructIndented(b, p, st)
@@ -1430,7 +1430,7 @@ func (e encoder) encodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 // b without colorization. It applies HTML escaping when EscapeHTML is set, and
 // best-effort indentation when an indenter is configured.
 func (e encoder) appendRawMessageVerbatim(b, s []byte) ([]byte, error) {
-	if e.indentr == nil || e.indentr.disabled {
+	if !e.indentr.enabled() {
 		if (e.flags & EscapeHTML) != 0 {
 			return appendCompactEscapeHTML(b, s), nil
 		}
@@ -1768,6 +1768,14 @@ func NewIndenter(prefix, indent string) *Indenter {
 }
 
 // push increases the indentation level.
+// enabled reports whether in produces indentation: a nil *Indenter and an
+// Indenter constructed with an empty prefix and indent are both disabled.
+// Every dispatcher that routes into an *Indented fast path, and every
+// caller of appendIndentFast, relies on this single definition.
+func (in *Indenter) enabled() bool {
+	return in != nil && !in.disabled
+}
+
 func (in *Indenter) push() {
 	if in != nil {
 		in.depth++
@@ -1784,7 +1792,7 @@ func (in *Indenter) pop() {
 // appendByte appends a to b if the Indenter is non-nil and enabled.
 // Otherwise b is returned unmodified.
 func (in *Indenter) appendByte(b []byte, a byte) []byte {
-	if in == nil || in.disabled {
+	if !in.enabled() {
 		return b
 	}
 
@@ -1794,7 +1802,7 @@ func (in *Indenter) appendByte(b []byte, a byte) []byte {
 // appendIndent writes indentation to b, returning the resulting slice.
 // If the Indenter is nil or disabled b is returned unchanged.
 func (in *Indenter) appendIndent(b []byte) []byte {
-	if in == nil || in.disabled {
+	if !in.enabled() {
 		return b
 	}
 
@@ -1805,6 +1813,8 @@ func (in *Indenter) appendIndent(b []byte) []byte {
 // non-nil and not disabled. Callers must verify those preconditions; the
 // colorless fast paths do so once per container, then call this directly
 // to skip the per-token nil/disabled check.
+// appendIndentFast appends the prefix and depth indentation without any
+// nil or disabled check. Callers must only reach it when in.enabled().
 func (in *Indenter) appendIndentFast(b []byte) []byte {
 	b = append(b, in.prefix...)
 	for i := 0; i < in.depth; i++ {

--- a/encode.go
+++ b/encode.go
@@ -18,19 +18,10 @@ import (
 const hex = "0123456789abcdef"
 
 func (e encoder) encodeNull(b []byte, _ unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil {
-		return append(b, "null"...), nil
-	}
 	return e.clrs.appendNull(b), nil
 }
 
 func (e encoder) encodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if e.clrs == nil {
-		if *(*bool)(p) {
-			return append(b, "true"...), nil
-		}
-		return append(b, "false"...), nil
-	}
 	return e.clrs.appendBool(b, *(*bool)(p)), nil
 }
 

--- a/json.go
+++ b/json.go
@@ -120,13 +120,6 @@ const (
 // construct an [Indenter] via [NewIndenter] to indent the output. The clrs
 // argument may be nil to disable colorization.
 func Append(b []byte, x interface{}, flags AppendFlags, clrs *Colors, indentr *Indenter) ([]byte, error) {
-	return appendInternal(b, x, flags, clrs, indentr, false)
-}
-
-// appendInternal is the shared implementation for Append. It carries
-// forceSlow through the recursion so parity tests can disable encode-time
-// fast paths and compare them against the colorized walk.
-func appendInternal(b []byte, x interface{}, flags AppendFlags, clrs *Colors, indentr *Indenter, forceSlow bool) ([]byte, error) {
 	if x == nil {
 		// Special case for nil values because it makes the rest of the code
 		// simpler to assume that it won't be seeing nil pointers.
@@ -143,7 +136,7 @@ func appendInternal(b []byte, x interface{}, flags AppendFlags, clrs *Colors, in
 		c = constructCachedCodec(t, cache)
 	}
 
-	b, err := c.encode(encoder{flags: flags, clrs: clrs, indentr: indentr, forceSlow: forceSlow}, b, p)
+	b, err := c.encode(encoder{flags: flags, clrs: clrs, indentr: indentr}, b, p)
 	if err != nil && indentr != nil {
 		// A failed encode can return from inside a push/pop pair, leaving
 		// the Indenter at a stale depth that would poison later calls, since

--- a/jsoncolor_internal_test.go
+++ b/jsoncolor_internal_test.go
@@ -74,13 +74,17 @@ var parityExtraValues = []interface{}{
 	[]interface{}{1, parityFuncField{}},
 }
 
+// slowColors is an empty, non-nil palette. The encoder takes the fast
+// paths only when clrs is nil, so passing slowColors routes the same
+// colorless encode through the general walk; since every Color is empty,
+// no ANSI escapes are written and the output must be byte-identical.
+var slowColors = &Colors{}
+
 // TestEncode_FastPathParity asserts that the colorless fast paths
 // produce byte-identical output to the general (slow) walk for every
-// value in testValues. Append (the public entry point) takes the fast
-// path when clrs is nil; appendInternal with forceSlow=true routes the
-// same colorless encode through the general walk instead. Neither side
-// emits color. The two outputs must be equal, otherwise the fast path
-// has diverged.
+// value in testValues. Append takes the fast path when clrs is nil;
+// slowColors forces the general walk. Neither side emits color. The two
+// outputs must be equal, otherwise the fast path has diverged.
 //
 // SortMapKeys is included in every config because map iteration is
 // otherwise nondeterministic across the two calls — without sorting,
@@ -118,7 +122,7 @@ func TestEncode_FastPathParity(t *testing.T) {
 					}
 
 					fast, fastErr := Append(nil, v, cfg.flags, nil, fastIndentr)
-					slow, slowErr := appendInternal(nil, v, cfg.flags, nil, slowIndentr, true)
+					slow, slowErr := Append(nil, v, cfg.flags, slowColors, slowIndentr)
 
 					if (fastErr == nil) != (slowErr == nil) {
 						t.Fatalf("error mismatch: fast=%v slow=%v", fastErr, slowErr)
@@ -160,8 +164,8 @@ type benchMixedRecord struct {
 // BenchmarkFastVsSlow compares the colorless fast path against the
 // general (slow) walk on identical data, with the output buffer pre-sized so
 // growth is not measured. The only variable is whether the fast path is
-// taken: fast=Append (forceSlow=false), slow=appendInternal with
-// forceSlow=true. Any nonzero delta is the fast path's contribution.
+// taken: fast=Append with nil colors, slow=Append with slowColors. Any
+// nonzero delta is the fast path's contribution.
 func BenchmarkFastVsSlow(b *testing.B) {
 	rec := benchMixedRecord{
 		I: 1, I64: 2, F32: 2.71, F64: 3.14,
@@ -196,7 +200,7 @@ func BenchmarkFastVsSlow(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					buf, _ = appendInternal(buf[:0], rec, EscapeHTML|SortMapKeys, nil, indentr, true)
+					buf, _ = Append(buf[:0], rec, EscapeHTML|SortMapKeys, slowColors, indentr)
 				}
 			})
 		})
@@ -224,7 +228,7 @@ func TestEncode_UnsortedMapErrorRollsBack(t *testing.T) {
 				prefix := []byte("prefix")
 
 				fast, fastErr := Append(append([]byte(nil), prefix...), v, 0, nil, indentr)
-				slow, slowErr := appendInternal(append([]byte(nil), prefix...), v, 0, nil, indentr, true)
+				slow, slowErr := Append(append([]byte(nil), prefix...), v, 0, slowColors, indentr)
 
 				if (fastErr == nil) != (slowErr == nil) {
 					t.Fatalf("error mismatch: fast=%v slow=%v", fastErr, slowErr)


### PR DESCRIPTION
## Summary

Cleanup of the fast-path work from #45, following the items in #69. Six
commits, each verified with the full suite, the race run and lint. Net effect:
`encode.go` goes from 1814 to 1649 lines, seven fast-path functions instead of
ten, and no measurable change on the fast-versus-slow micro-benchmark.

1. **Drop `forceSlow`.** The flag on the encoder struct, the `appendInternal`
   wrapper and its sixth parameter, and the extra clause on nineteen dispatch
   gates are gone. The parity test and benchmark use `&Colors{}` as the slow
   reference, which reaches the general walk with byte-identical output since
   #64.
2. **`Indenter.enabled()`** owns the nil-or-disabled definition at all eight
   sites, and inlines everywhere.
3. **Map fast paths consolidated; struct and array kept split.** Measurement
   decided how far to go. Folding all five containers into one function each
   cost the struct and array fast paths 2.4% and 4.7%, roughly half their
   advantage, from the per-element branch on the indentation bool. The three
   map kinds lost nothing from folding, so they are now one function each with
   a shared `appendFastMember` helper and the two-variable range form in place
   of the key-then-index lookup. Struct and array keep their Plain and Indented
   variants as the reference shape.
4. **Null and bool encoders** call the `Colors` helpers directly; both inline
   under budget and begin with the same nil check the encoders duplicated. The
   int and uint helpers do not inline, so those encoders keep their guards.
5. **Bytes-only key writer.** `doEncodeString` returns bytes only, since it
   could never fail; `appendKey` serves the string-keyed map paths; `encodeKey`
   remains as the `encodeFunc` wrapper that `codec.go` installs for
   string-keyed reflect maps. Every error check and blank assignment on a
   string key is gone.
6. **Pool handling kept inline.** The first `getMapslice` and `release`
   helpers landed just over the inlining budget and showed as a small
   regression on the colored path in a per-commit bisect. `release` now uses
   `clear` and inlines; the pool get is written at its four sites with the rare
   growth path in an out-of-line `grow`.

## Benchmarks

Against `origin/master`, M1 Max, n=8, benchstat:

| benchmark | change |
|---|---|
| `BenchmarkFastVsSlow`, all four cells | no significant change |
| `BenchmarkEncode` compact, no color | +1.0% |
| `BenchmarkEncode` indented, no color | +1.4% |
| `BenchmarkEncode` compact, color | no significant change |
| `BenchmarkEncode` indented, color | -1.7% |

The residual on the uncolored cells is the consolidated map fast paths, which
still beat the slow walk but by less than the old split copies did. Recovering
it would mean re-splitting the maps, which undoes most of the code reduction.

Closes #69

## Checklist

- [x] Tests added or updated (parity test now uses `&Colors{}` as the slow reference)
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] CHANGELOG entry added to `README.md` under the current version heading. Internal cleanup with no behavior change; a one-line entry can go in the release it ships with.
