### PR TITLE
Skip fields promoted through a nil embedded pointer before writing them

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -182,3 +182,79 @@ func newEncNwidger(w io.Writer, indent, color bool) encoder {
 
 	return enc
 }
+
+// embedPtrInner is embedded by pointer in embedPtrOuter. Its fields are
+// promoted through the pointer, so each one pays the promotion overhead on
+// every encode; the type has enough of them that that overhead dominates.
+type embedPtrInner struct {
+	F0 int
+	F1 int
+	F2 int
+	F3 int
+	F4 int
+	F5 int
+	F6 int
+	F7 int
+}
+
+type embedPtrOuter struct {
+	A int
+	*embedPtrInner
+	C int
+}
+
+// embedPtrFlat has the same fields as embedPtrOuter, declared directly. It is
+// the control: the struct encoder's per-field checks run on every field, so
+// a change to those checks shows up here even without an embedded pointer.
+type embedPtrFlat struct {
+	A  int
+	F0 int
+	F1 int
+	F2 int
+	F3 int
+	F4 int
+	F5 int
+	F6 int
+	F7 int
+	C  int
+}
+
+// BenchmarkEncode_EmbeddedPointer measures the struct encoder on fields
+// promoted through an embedded struct pointer, with the pointer set and nil,
+// against a flat struct with the same fields. See issue #70.
+func BenchmarkEncode_EmbeddedPointer(b *testing.B) {
+	values := []struct {
+		name string
+		v    interface{}
+	}{
+		{name: "nonnil", v: embedPtrOuter{A: 1, embedPtrInner: &embedPtrInner{1, 2, 3, 4, 5, 6, 7, 8}, C: 2}},
+		{name: "nil", v: embedPtrOuter{A: 1, C: 2}},
+		{name: "flat", v: embedPtrFlat{1, 1, 2, 3, 4, 5, 6, 7, 8, 2}},
+	}
+
+	palettes := []struct {
+		name string
+		clrs *jsoncolor.Colors
+	}{
+		{name: "nocolor", clrs: nil},
+		{name: "color", clrs: jsoncolor.DefaultColors()},
+	}
+
+	for _, pal := range palettes {
+		for _, val := range values {
+			b.Run(pal.name+"/"+val.name, func(b *testing.B) {
+				buf := &bytes.Buffer{}
+				enc := jsoncolor.NewEncoder(buf)
+				enc.SetColors(pal.clrs)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for n := 0; n < b.N; n++ {
+					buf.Reset()
+					if err := enc.Encode(val.v); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/codec.go
+++ b/codec.go
@@ -986,25 +986,65 @@ type structType struct {
 	typ         reflect.Type
 }
 
+// structField is the per-field entry in a structType. It is computed once
+// per struct type by constructStructType and cached, so the struct encoders
+// and decoder can walk a value without consulting reflect: each field is
+// reached by adding offset to the struct's address and handed to codec.
+//
+// Fields promoted from embedded structs appear here alongside the struct's
+// own fields, already resolved for ambiguity and dominance as encoding/json
+// specifies, and sorted into declaration order by index.
 type structField struct {
-	codec  codec
+	// codec encodes and decodes the field's value, given its address.
+	codec codec
+
+	// offset is the field's byte offset from the address of the enclosing
+	// struct. For a field promoted through an embedded struct pointer
+	// (fieldViaPointer), it is the offset of that pointer word instead, and
+	// ptrOffset completes the path.
 	offset uintptr
-	empty  emptyFunc
-	tag    bool
+
+	// empty reports whether the value at the field's address is empty in
+	// the omitempty sense. It is consulted only when fieldOmitEmpty is set.
+	empty emptyFunc
+
+	// tag reports that name came from a json struct tag rather than the Go
+	// field name. When promoted fields collide on a name, a tagged field
+	// dominates untagged ones; it is cleared on promotion so that dominance
+	// does not carry more than one level up.
+	tag bool
+
 	// flags holds the per-field conditions the struct encoders test before
 	// writing a field. They share one byte so that a field with neither set,
 	// the common case, costs a single test in the encode loop.
 	flags fieldFlags
+
 	// ptrOffset applies to a fieldViaPointer field: the offset of the field
 	// (or, for deeper chains, of the next pointer word) from the target of
 	// the pointer that offset addresses.
 	ptrOffset uintptr
-	json      string
-	html      string
-	name      string
-	typ       reflect.Type
-	zero      reflect.Value
-	index     int
+
+	// json and html are the field's key as it is written to the output:
+	// name quoted and escaped, without and with HTML escaping respectively.
+	// They are precomputed so the encoders append them as-is.
+	json string
+	html string
+
+	// name is the JSON member name, from the json tag if present, otherwise
+	// the Go field name. The decoder looks fields up by it.
+	name string
+
+	// typ and zero are the field's Go type and its zero value. Neither is
+	// consulted by the encoder or decoder; they are retained from the
+	// upstream implementation.
+	typ  reflect.Type
+	zero reflect.Value
+
+	// index orders the fields as declared in the Go struct: the top-level
+	// field index in the high 32 bits, and for a promoted field the index
+	// within the embedded struct in the low 32 bits, so promoted fields sit
+	// where their embedding field is declared.
+	index int
 }
 
 // fieldFlags is the set of conditions in structField.flags.

--- a/codec.go
+++ b/codec.go
@@ -15,23 +15,43 @@ import (
 	"unsafe"
 )
 
+// codec is the pair of functions that encode and decode values of one Go
+// type. constructCodec builds one per type, composing the codecs of element,
+// key and field types, and the type-to-codec cache (see cacheLoad and
+// cacheStore) memoizes the result, so the reflect work happens once per type
+// rather than once per value.
 type codec struct {
 	encode encodeFunc
 	decode decodeFunc
 }
 
+// encoder carries the per-call state of an encode walk: the AppendFlags in
+// effect, the color palette, and the indenter. It is passed by value to
+// every encodeFunc. A nil clrs selects the colorless fast paths; a nil or
+// disabled indentr produces compact output.
 type encoder struct {
 	flags   AppendFlags
 	clrs    *Colors
 	indentr *Indenter
 }
+
+// decoder carries the per-call state of a decode walk, which is just the
+// ParseFlags in effect. It is passed by value to every decodeFunc.
 type decoder struct{ flags ParseFlags }
 
+// encodeFunc appends the JSON encoding of the value at p to b and returns
+// the extended buffer. decodeFunc parses a value from b into the memory at
+// p and returns the unconsumed remainder. In both, p addresses a value of
+// the Go type the function was constructed for; the caller guarantees the
+// type, so the functions read and write through p without checks.
 type (
 	encodeFunc func(encoder, []byte, unsafe.Pointer) ([]byte, error)
 	decodeFunc func(decoder, []byte, unsafe.Pointer) ([]byte, error)
 )
 
+// emptyFunc reports whether the value at p is empty for the purposes of the
+// omitempty tag; emptyFuncOf builds one per type. sortFunc orders a slice of
+// map keys in place for SortMapKeys; constructMapCodec picks one by key type.
 type (
 	emptyFunc func(unsafe.Pointer) bool
 	sortFunc  func([]reflect.Value)
@@ -511,13 +531,33 @@ func constructEmbeddedStructPointerDecodeFunc(t reflect.Type, unexported bool, o
 	}
 }
 
+// embeddedField is a candidate for promotion: one field of a struct that is
+// embedded, by value or by pointer, in the struct type being constructed.
+// appendStructFields collects these for every embedded struct, resolves
+// which of them encoding/json would promote, and copies the survivors into
+// the outer struct's field list as structField entries.
 type embeddedField struct {
-	index      int
-	offset     uintptr
-	pointer    bool
+	// index is the ordering key the promoted field will carry: the
+	// embedding field's index in the high 32 bits and the field's own index
+	// within the embedded struct in the low 32 bits.
+	index int
+
+	// offset is the byte offset of the embedding field from the address of
+	// the outer struct: the start of the embedded struct when embedded by
+	// value, or of the pointer word when embedded by pointer.
+	offset uintptr
+
+	// pointer reports that the struct is embedded by pointer.
+	pointer bool
+
+	// unexported reports that the embedding field is unexported. Decoding
+	// cannot allocate through such a pointer when it is nil.
 	unexported bool
-	subtype    *structType
-	subfield   *structField
+
+	// subtype is the embedded struct's own structType, and subfield the
+	// entry in it that is being considered for promotion.
+	subtype  *structType
+	subfield *structField
 }
 
 // promoteThroughPointer adapts a field promoted through an embedded struct
@@ -968,22 +1008,40 @@ func emptyFuncOf(t reflect.Type) emptyFunc {
 	return func(unsafe.Pointer) bool { return false }
 }
 
+// iface mirrors the runtime layout of an interface value, so that a codec
+// given the address of an interface can test it for nil without reflect.
 type iface struct {
 	typ unsafe.Pointer
 	ptr unsafe.Pointer
 }
 
+// slice mirrors the runtime layout of a slice header, so that a codec given
+// the address of a slice can read its length without reflect.
 type slice struct {
 	data unsafe.Pointer
 	len  int
 	cap  int
 }
 
+// structType is the cached description of a struct type that the struct
+// encoders and decoder walk. constructStructType builds it once per Go
+// type, including the fields promoted from embedded structs, and the codec
+// for the type closes over it.
 type structType struct {
-	fields      []structField
+	// fields lists the members to encode, in output order.
+	fields []structField
+
+	// fieldsIndex maps each JSON member name to its field, for the decoder's
+	// exact-match lookup.
 	fieldsIndex map[string]*structField
+
+	// ficaseIndex maps each lower-cased member name to the first field
+	// declared with it, for the decoder's case-insensitive fallback when an
+	// exact match fails, as encoding/json does.
 	ficaseIndex map[string]*structField
-	typ         reflect.Type
+
+	// typ is the Go struct type, used in error messages.
+	typ reflect.Type
 }
 
 // structField is the per-field entry in a structType. It is computed once

--- a/codec.go
+++ b/codec.go
@@ -482,13 +482,6 @@ func constructStructDecodeFunc(st *structType) decodeFunc {
 	}
 }
 
-func constructEmbeddedStructPointerCodec(t reflect.Type, unexported bool, offset uintptr, field codec) codec {
-	return codec{
-		encode: constructEmbeddedStructPointerEncodeFunc(t, unexported, offset, field.encode),
-		decode: constructEmbeddedStructPointerDecodeFunc(t, unexported, offset, field.decode),
-	}
-}
-
 // constructEmbeddedStructPointerEmptyFunc wraps the emptiness check of a
 // field promoted through an embedded struct pointer. Like the codec wrapper
 // above, the returned function receives the address of the pointer word in
@@ -528,18 +521,47 @@ type embeddedField struct {
 }
 
 // promoteThroughPointer adapts a field promoted through an embedded struct
-// pointer. The codec, and for omitempty fields the emptiness check, are
-// wrapped to dereference the pointer, and the offset is re-pointed at the
-// pointer word in the outer struct. Non-omitempty fields never consult the
-// emptiness check, so they skip that wrapper.
+// pointer. On return, offset addresses the pointer word in the outer struct,
+// fieldViaPointer is set, and ptrOffset holds the field's offset from the pointer
+// target, so the struct encoders can read the pointer, omit the field when it
+// is nil, and otherwise call the codec on the dereferenced address, all
+// without an intermediate wrapper (#70).
+//
+// The decode side keeps the wrapper at every level, because decoding must
+// allocate the embedded struct when the pointer is nil. The emptiness check
+// is wrapped in two cases: a field tagged omitempty must be tested through
+// the pointer (#59), and a field that is not omitempty but is itself promoted
+// through a further embedded pointer needs a check that the inner pointer is
+// non-nil, since the encoders read only the outermost pointer word, so that
+// check becomes a synthesized omitempty. The inner dereference that such a
+// field needed moves into an encode wrapper. Each level wraps the function
+// from the level below, so deeper chains compose.
 func promoteThroughPointer(embfield embeddedField, subfield structField) structField {
-	subfield.codec = constructEmbeddedStructPointerCodec(embfield.subtype.typ, embfield.unexported, subfield.offset, subfield.codec)
-	if subfield.omitempty {
+	typ, unexported := embfield.subtype.typ, embfield.unexported
+
+	subfield.codec.decode = constructEmbeddedStructPointerDecodeFunc(typ, unexported, subfield.offset, subfield.codec.decode)
+
+	switch {
+	case subfield.flags&fieldOmitEmpty != 0:
 		subfield.empty = constructEmbeddedStructPointerEmptyFunc(subfield.offset, subfield.empty)
+	case subfield.flags&fieldViaPointer != 0:
+		subfield.empty = constructEmbeddedStructPointerEmptyFunc(subfield.offset, pointerIsNil)
+		subfield.flags |= fieldOmitEmpty
 	}
+
+	if subfield.flags&fieldViaPointer != 0 {
+		subfield.codec.encode = constructEmbeddedStructPointerEncodeFunc(typ, unexported, subfield.ptrOffset, subfield.codec.encode)
+	}
+
+	subfield.flags |= fieldViaPointer
+	subfield.ptrOffset = subfield.offset
 	subfield.offset = embfield.offset
 	return subfield
 }
+
+// pointerIsNil is the emptiness check for a pointer word. It is the
+// building block promoteThroughPointer uses for inner embedded pointers.
+func pointerIsNil(p unsafe.Pointer) bool { return *(*unsafe.Pointer)(p) == nil }
 
 func appendStructFields(fields []structField, t reflect.Type, offset uintptr, seen map[reflect.Type]*structType, canAddr bool) []structField {
 	names := make(map[string]struct{})
@@ -552,7 +574,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 			name             = f.Name
 			anonymous        = f.Anonymous
 			isTag            = false
-			omitempty        = false
+			flags            fieldFlags
 			stringifyEnabled = false
 			unexported       = len(f.PkgPath) != 0
 		)
@@ -577,7 +599,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 			for _, tag := range parts[1:] {
 				switch tag {
 				case "omitempty":
-					omitempty = true
+					flags |= fieldOmitEmpty
 				case "string":
 					stringifyEnabled = true
 				}
@@ -625,15 +647,15 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 		}
 
 		fields = append(fields, structField{
-			codec:     c,
-			offset:    offset + f.Offset,
-			empty:     emptyFuncOf(f.Type),
-			tag:       isTag,
-			omitempty: omitempty,
-			name:      name,
-			index:     i << 32,
-			typ:       f.Type,
-			zero:      reflect.Zero(f.Type),
+			codec:  c,
+			offset: offset + f.Offset,
+			empty:  emptyFuncOf(f.Type),
+			tag:    isTag,
+			flags:  flags,
+			name:   name,
+			index:  i << 32,
+			typ:    f.Type,
+			zero:   reflect.Zero(f.Type),
 		})
 
 		names[name] = struct{}{}
@@ -965,11 +987,18 @@ type structType struct {
 }
 
 type structField struct {
-	codec     codec
-	offset    uintptr
-	empty     emptyFunc
-	tag       bool
-	omitempty bool
+	codec  codec
+	offset uintptr
+	empty  emptyFunc
+	tag    bool
+	// flags holds the per-field conditions the struct encoders test before
+	// writing a field. They share one byte so that a field with neither set,
+	// the common case, costs a single test in the encode loop.
+	flags fieldFlags
+	// ptrOffset applies to a fieldViaPointer field: the offset of the field
+	// (or, for deeper chains, of the next pointer word) from the target of
+	// the pointer that offset addresses.
+	ptrOffset uintptr
 	json      string
 	html      string
 	name      string
@@ -977,6 +1006,24 @@ type structField struct {
 	zero      reflect.Value
 	index     int
 }
+
+// fieldFlags is the set of conditions in structField.flags.
+type fieldFlags uint8
+
+const (
+	// fieldOmitEmpty marks a field whose emptiness check, empty, decides
+	// whether it is written. It comes from the omitempty tag, and is also
+	// synthesized for a field promoted through more than one level of
+	// embedded struct pointers, whose inner pointer may be nil.
+	fieldOmitEmpty fieldFlags = 1 << iota
+
+	// fieldViaPointer marks a field promoted through an embedded struct
+	// pointer. offset then addresses the outermost such pointer word in the
+	// enclosing struct. The struct encoders skip the field when the pointer
+	// is nil, as encoding/json does, and otherwise encode it at
+	// target+ptrOffset. See issues #56 and #70.
+	fieldViaPointer
+)
 
 func unmarshalTypeError(b []byte, t reflect.Type) error {
 	return &UnmarshalTypeError{Value: strconv.Quote(prefix(b)), Type: t}

--- a/encode.go
+++ b/encode.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding"
 	"encoding/base64"
-	"errors"
 	"math"
 	"reflect"
 	"sort"
@@ -1023,14 +1022,24 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		f := &st.fields[i]
 		v := unsafe.Pointer(uintptr(p) + f.offset)
 
-		if f.omitempty && f.empty(v) {
-			continue
-		}
+		if f.flags != 0 {
+			if f.flags&fieldOmitEmpty != 0 && f.empty(v) {
+				continue
+			}
 
-		// fieldStart is the rollback point: everything appended for this
-		// field, including its separator, is discarded if the field's codec
-		// returns rollback (e.g. a nil embedded struct pointer). See #56.
-		fieldStart := len(b)
+			// A field promoted through an embedded struct pointer is omitted
+			// when the pointer is nil, as encoding/json does, and is otherwise
+			// encoded at its offset from the pointer's target. The nil check
+			// runs before anything is written for the field, so there is
+			// nothing to undo. See issues #56 and #70.
+			if f.flags&fieldViaPointer != 0 {
+				q := *(*unsafe.Pointer)(v)
+				if q == nil {
+					continue
+				}
+				v = unsafe.Pointer(uintptr(q) + f.ptrOffset)
+			}
+		}
 
 		if n != 0 {
 			b = e.clrs.appendPunc(b, ',')
@@ -1059,10 +1068,6 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		b = e.indentr.appendByte(b, ' ')
 
 		if b, err = f.codec.encode(e, b, v); err != nil {
-			if errors.Is(err, rollback{}) {
-				b = b[:fieldStart]
-				continue
-			}
 			return b[:start], err
 		}
 
@@ -1091,12 +1096,20 @@ func (e encoder) encodeStructPlain(b []byte, p unsafe.Pointer, st *structType) (
 		f := &st.fields[i]
 		v := unsafe.Pointer(uintptr(p) + f.offset)
 
-		if f.omitempty && f.empty(v) {
-			continue
-		}
+		if f.flags != 0 {
+			if f.flags&fieldOmitEmpty != 0 && f.empty(v) {
+				continue
+			}
 
-		// fieldStart is the rollback point; see encodeStruct.
-		fieldStart := len(b)
+			// Promoted through an embedded struct pointer; see encodeStruct.
+			if f.flags&fieldViaPointer != 0 {
+				q := *(*unsafe.Pointer)(v)
+				if q == nil {
+					continue
+				}
+				v = unsafe.Pointer(uintptr(q) + f.ptrOffset)
+			}
+		}
 
 		if n != 0 {
 			b = append(b, ',')
@@ -1113,10 +1126,6 @@ func (e encoder) encodeStructPlain(b []byte, p unsafe.Pointer, st *structType) (
 
 		var err error
 		if b, err = f.codec.encode(e, b, v); err != nil {
-			if errors.Is(err, rollback{}) {
-				b = b[:fieldStart]
-				continue
-			}
 			return b[:start], err
 		}
 
@@ -1139,12 +1148,20 @@ func (e encoder) encodeStructIndented(b []byte, p unsafe.Pointer, st *structType
 		f := &st.fields[i]
 		v := unsafe.Pointer(uintptr(p) + f.offset)
 
-		if f.omitempty && f.empty(v) {
-			continue
-		}
+		if f.flags != 0 {
+			if f.flags&fieldOmitEmpty != 0 && f.empty(v) {
+				continue
+			}
 
-		// fieldStart is the rollback point; see encodeStruct.
-		fieldStart := len(b)
+			// Promoted through an embedded struct pointer; see encodeStruct.
+			if f.flags&fieldViaPointer != 0 {
+				q := *(*unsafe.Pointer)(v)
+				if q == nil {
+					continue
+				}
+				v = unsafe.Pointer(uintptr(q) + f.ptrOffset)
+			}
+		}
 
 		if n != 0 {
 			b = append(b, ',')
@@ -1164,10 +1181,6 @@ func (e encoder) encodeStructIndented(b []byte, p unsafe.Pointer, st *structType
 
 		var err error
 		if b, err = f.codec.encode(e, b, v); err != nil {
-			if errors.Is(err, rollback{}) {
-				b = b[:fieldStart]
-				continue
-			}
 			return b[:start], err
 		}
 
@@ -1184,14 +1197,17 @@ func (e encoder) encodeStructIndented(b []byte, p unsafe.Pointer, st *structType
 	return append(b, '}'), nil
 }
 
-type rollback struct{}
-
-func (rollback) Error() string { return "rollback" }
-
+// encodeEmbeddedStructPointer encodes a field promoted through the second or
+// deeper level of a chain of embedded struct pointers: p addresses an inner
+// pointer word, which is dereferenced here. The outermost pointer is handled
+// by the struct encoders (see fieldViaPointer), and a nil inner
+// pointer is caught by the field's synthesized omitempty check before the
+// codec is called, so p is non-nil here in practice. Should a nil pointer
+// arrive anyway, it encodes as null, which keeps the output well-formed.
 func (e encoder) encodeEmbeddedStructPointer(b []byte, p unsafe.Pointer, _ reflect.Type, _ bool, offset uintptr, encode encodeFunc) ([]byte, error) {
 	p = *(*unsafe.Pointer)(p)
 	if p == nil {
-		return b, rollback{}
+		return e.clrs.appendNull(b), nil
 	}
 	return encode(e, b, unsafe.Pointer(uintptr(p)+offset))
 }

--- a/encode.go
+++ b/encode.go
@@ -616,12 +616,19 @@ func (e encoder) encodeMapFast(b []byte, p unsafe.Pointer, t reflect.Type, encod
 	return append(b, '}'), nil
 }
 
+// element is one member of a map being encoded with SortMapKeys: its key
+// and either its value, for map[string]interface{}, or its raw bytes, for
+// map[string]RawMessage.
 type element struct {
 	key string
 	val interface{}
 	raw RawMessage
 }
 
+// mapslice collects the members of a map so that they can be sorted by key
+// before encoding. It implements sort.Interface, and instances are pooled in
+// mapslicePool so the sorted encodings of string-keyed maps do not allocate
+// per call.
 type mapslice struct {
 	elements []element
 }

--- a/json.go
+++ b/json.go
@@ -465,4 +465,7 @@ var encoderBufferPool = sync.Pool{
 	New: func() interface{} { return &encoderBuffer{data: make([]byte, 0, 4096)} },
 }
 
+// encoderBuffer is the reusable output buffer that Marshal and Encoder.Encode
+// borrow from encoderBufferPool for the duration of one encode. Pooling a
+// wrapper rather than the slice itself avoids an allocation on Put.
 type encoderBuffer struct{ data []byte }

--- a/jsoncolor_internal_test.go
+++ b/jsoncolor_internal_test.go
@@ -58,7 +58,7 @@ type parityAllOmitEmpty struct {
 type parityFuncField struct{ F func() }
 
 // parityExtraValues supplements the vendored testValues with shapes that
-// exercise struct rollback, omitempty through embedded pointers, empty
+// exercise nil embedded struct pointers, omitempty through embedded pointers, empty
 // indented structs, and encode errors, on both the fast and slow paths.
 var parityExtraValues = []interface{}{
 	parityNilEmbedOnly{},

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -813,6 +813,18 @@ type nilEmbedLast struct {
 	*nilEmbedInner
 }
 
+type nilEmbedL1 struct {
+	*nilEmbedInner
+}
+
+// nilEmbedChain promotes X through two levels of embedded pointers, so the
+// nil can sit at either level.
+type nilEmbedChain struct {
+	A int
+	*nilEmbedL1
+	C int
+}
+
 // ansiRe matches ANSI SGR escape sequences.
 var ansiRe = regexp.MustCompile("\x1b\\[[0-9;]*m")
 
@@ -827,6 +839,9 @@ func TestEncode_NilEmbeddedStructPointer(t *testing.T) {
 		nilEmbedFirst{A: 1, C: 2},
 		nilEmbedMiddle{A: 1, C: 2},
 		nilEmbedLast{A: 1, C: 2},
+		nilEmbedChain{A: 1, C: 2},
+		nilEmbedChain{A: 1, nilEmbedL1: &nilEmbedL1{}, C: 2},
+		nilEmbedChain{A: 1, nilEmbedL1: &nilEmbedL1{nilEmbedInner: &nilEmbedInner{X: 3}}, C: 2},
 	}
 
 	palettes := []struct {
@@ -837,10 +852,10 @@ func TestEncode_NilEmbeddedStructPointer(t *testing.T) {
 		{name: "color", clrs: jsoncolor.DefaultColors()},
 	}
 
-	for _, v := range values {
+	for i, v := range values {
 		for _, pal := range palettes {
 			for _, indent := range []bool{false, true} {
-				name := fmt.Sprintf("%T/%s/indent=%v", v, pal.name, indent)
+				name := fmt.Sprintf("%d_%T/%s/indent=%v", i, v, pal.name, indent)
 				t.Run(name, func(t *testing.T) {
 					var want []byte
 					var err error

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -786,7 +786,7 @@ func TestAppendIndenter(t *testing.T) {
 }
 
 // nilEmbedInner is embedded by pointer in the structs below. When the pointer
-// is nil, the encoder must roll back the promoted field cleanly.
+// is nil, the encoder must omit the promoted field cleanly.
 type nilEmbedInner struct {
 	X int
 }
@@ -825,12 +825,20 @@ type nilEmbedChain struct {
 	C int
 }
 
+// nilEmbedValueOuter embeds nilEmbedL1 by value, so X is promoted through a
+// value embed and then a pointer embed.
+type nilEmbedValueOuter struct {
+	A int
+	nilEmbedL1
+	C int
+}
+
 // ansiRe matches ANSI SGR escape sequences.
 var ansiRe = regexp.MustCompile("\x1b\\[[0-9;]*m")
 
 // TestEncode_NilEmbeddedStructPointer verifies that a nil embedded struct
 // pointer does not leave a dangling separator or newline behind when its
-// promoted field is rolled back, regardless of position, colorization or
+// promoted field is omitted, regardless of position, colorization or
 // indentation. Output (with ANSI stripped) must match encoding/json exactly.
 // See issue #56.
 func TestEncode_NilEmbeddedStructPointer(t *testing.T) {
@@ -842,6 +850,8 @@ func TestEncode_NilEmbeddedStructPointer(t *testing.T) {
 		nilEmbedChain{A: 1, C: 2},
 		nilEmbedChain{A: 1, nilEmbedL1: &nilEmbedL1{}, C: 2},
 		nilEmbedChain{A: 1, nilEmbedL1: &nilEmbedL1{nilEmbedInner: &nilEmbedInner{X: 3}}, C: 2},
+		nilEmbedValueOuter{A: 1, C: 2},
+		nilEmbedValueOuter{A: 1, nilEmbedL1: nilEmbedL1{nilEmbedInner: &nilEmbedInner{X: 3}}, C: 2},
 	}
 
 	palettes := []struct {

--- a/token.go
+++ b/token.go
@@ -77,11 +77,17 @@ type Tokenizer struct {
 	buffer [8]state
 }
 
+// state is one entry of the Tokenizer's container stack: the kind of
+// container being tokenized and the number of values seen in it so far,
+// which is what drives Tokenizer.Index and, for objects, the alternation
+// between keys and values.
 type state struct {
 	typ scope
 	len int
 }
 
+// scope identifies the kind of container a Tokenizer is inside: an array or
+// an object.
 type scope int
 
 const (


### PR DESCRIPTION
Closes #70.

## What

A nil embedded struct pointer was signalled by the promoted field's codec returning a `rollback{}` sentinel. Each of the three struct encoders caught it with `errors.Is` after already appending the separator, newline, indent, key and colon, then truncated back to a saved `fieldStart`. Every promoted field of a nil embed paid an append-then-truncate cycle and an `errors.Is` call, and the dance had to be replicated in each encoder variant.

The struct encoders now handle the pointer themselves:

- A field promoted through an embedded pointer carries the `fieldViaPointer` flag and a `ptrOffset`. The loop reads the pointer word at the field's offset, skips the field when it is nil (as `encoding/json` does) **before anything is written**, and otherwise calls the field's plain codec on the dereferenced address.
- That removes the encode-side wrapper closure and its second dereference for the outermost level, so non-nil promoted fields get cheaper as well. The decode wrapper stays at every level, since decoding must allocate the embedded struct on nil.
- Deeper chains compose: a field already promoted through an inner pointer keeps that dereference in an encode wrapper, and its inner nil check becomes a synthesized omitempty using the existing emptiness wrapper from #59.
- `omitempty` becomes a bit in the same `flags` byte as `fieldViaPointer`, so a field with neither set still costs the encode loop a single test. (A first cut with two separate bools cost flat structs ~1.5%.)
- `rollback`, its three catch sites, `errors.Is` and the `fieldStart` bookkeeping are deleted. `encodeEmbeddedStructPointer`, now only reached for inner levels, encodes a nil pointer as `null` rather than returning an error, so output stays well-formed even if a caller ever skips the check.

## Documentation

Two follow-up commits add doc comments to `structField` (per field, including the dual meaning of `offset` for pointer-promoted fields and how `index` keeps declaration order) and to every other previously undocumented type in the package: `codec`, `encoder`, `decoder`, the `encodeFunc`/`decodeFunc` and `emptyFunc`/`sortFunc` pairs, `embeddedField`, `iface`, `slice`, `structType`, `element`, `mapslice`, `encoderBuffer`, and the tokenizer's `state` and `scope`. No code changes in those commits.

While documenting `structField`, I found that its `typ` and `zero` fields are not read anywhere by the encoder or decoder; they are retained from upstream and the comment says so.

## Tests

- `TestEncode_NilEmbeddedStructPointer` gains a two-level pointer chain with the nil at either level, and a value embed containing a pointer embed (the offset-add branch must keep the flag). All 36 subtests match `encoding/json` exactly, with and without colors and indentation.
- `TestEncode_OmitEmptyThroughEmbeddedPointer` (#59) and the fast-path parity test's nil-embed values pass unchanged.
- New permanent `BenchmarkEncode_EmbeddedPointer`: promoted fields with the pointer set, with it nil, and a flat control struct with the same fields.

## Performance

Interleaved runs (old and new test binaries alternated, so drift cannot favour either side), benchstat vs the first commit on this branch, which is `origin/master` plus the benchmark:

```
                                         │   old   │   new    vs base
Encode_EmbeddedPointer/nocolor/nonnil     145.4n     135.6n   -6.74% (p=0.000 n=12)
Encode_EmbeddedPointer/nocolor/nil        138.85n     51.99n  -62.56% (p=0.000 n=12)
Encode_EmbeddedPointer/nocolor/flat       133.7n     133.0n   ~      (p=0.259 n=12)
Encode_EmbeddedPointer/color/nonnil       211.8n     201.6n   -4.79% (p=0.000 n=12)
Encode_EmbeddedPointer/color/nil          182.45n     69.07n  -62.15% (p=0.000 n=12)
Encode_EmbeddedPointer/color/flat         198.4n     197.8n   ~      (p=0.523 n=12)

Encode/neilotoole_NoIndent_NoColor        5.226m     5.203m   ~ (p=0.279 n=8)
Encode/neilotoole_Indent_NoColor          6.165m     6.230m   ~ (p=0.798 n=8)
Encode/neilotoole_NoIndent_Color          5.965m     5.930m   ~ (p=0.328 n=8)
Encode/neilotoole_Indent_Color            6.845m     6.849m   ~ (p=0.959 n=8)
```

No allocation changes. `go test -race ./...` and golangci-lint are clean.
