### PR TITLE
Document the fixed ANSI reset that closes every colorized token (#75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,27 @@ func DefaultColors() *Colors {
 As seen above, use the `Color` zero value (`Color{}`) to
 disable colorization for that JSON element.
 
+### Color reset
+
+`Color` is the prefix only. The encoder closes every colorized token with the
+fixed sequence `\x1b[0m` (SGR 0), and there is no way for a caller to supply a
+different closer.
+
+`\x1b[0m` resets *every* terminal attribute, not just the ones the prefix set.
+That is the safe default: no attribute can leak out of a token. The trade-off is
+composability. jsoncolor output is not safe to nest inside a region that is
+already styled, because the first colorized token clears that styling for the
+remainder of the output. Rendering colorized JSON inside a diff line that has a
+background color, inside a TUI panel with an inherited style, or after a styled
+log prefix will each drop the surrounding style.
+
+An attribute-specific closer (`\x1b[39m` for "default foreground", `\x1b[22m`
+for "normal intensity", and so on) would leave untouched attributes alone, but
+jsoncolor cannot compute one. `Color` arrives as already-rendered opaque bytes,
+so given `\x1b[34;1m` the encoder has no way to know that those parameters mean
+blue and bold. See [#75](https://github.com/neilotoole/jsoncolor/issues/75) for
+the full analysis, including the API options if this is ever addressed.
+
 ### Helper for `fatih/color`
 
 It can be inconvenient to use terminal codes, e.g. `json.Color("\x1b[36m")`.

--- a/jsoncolor.go
+++ b/jsoncolor.go
@@ -2,6 +2,10 @@ package jsoncolor
 
 // Colors specifies colorization of JSON output. Each field
 // is a Color, which is simply the bytes of the terminal color code.
+//
+// Each field supplies only the prefix for its token class; the encoder always
+// closes a colorized token with the fixed ANSI reset "\x1b[0m". See [Color]
+// for what that means when jsoncolor output is nested inside styled output.
 type Colors struct {
 	// Null is the color for JSON nil.
 	Null Color
@@ -177,6 +181,19 @@ func (c *Colors) textMarshalerColor() Color {
 // Example value:
 //
 //	number := Color("\x1b[36m")
+//
+// Color is the prefix only: there is no mechanism for a caller to supply a
+// closer. Every colorized token is closed with the fixed sequence "\x1b[0m"
+// (SGR 0), which resets every terminal attribute, not merely those that the
+// prefix set. No attribute can leak out of a token, which is why this is the
+// default, but it does mean that jsoncolor output is not safe to nest inside
+// an already-styled region: the first colorized token clears the ambient
+// styling, and it stays cleared for the remainder of the output.
+//
+// So, writing colorized JSON into a line that carries a background color, or
+// into a TUI panel with an inherited style, drops that style at the first
+// token. A caller needing the surrounding style preserved must re-apply it
+// after encoding, or write the JSON outside the styled region.
 type Color []byte
 
 // ansiReset is the ANSI ansiReset escape code.


### PR DESCRIPTION
## Summary

Every colorized token is closed with the package constant `ansiReset`
(`\x1b[0m`, SGR 0), which resets *all* terminal attributes rather than only
those the prefix set. That is a sound default — no attribute can leak out of a
token — but it means jsoncolor output is not safe to nest inside an
already-styled region, and nothing in the docs said so.

This is documentation only; no behavior change, no exported API change.

- **`Color` godoc**: states that `Color` is the prefix only with no mechanism
  for a caller to supply a closer, that the closer is always `\x1b[0m`, and
  what that means for nesting inside styled output.
- **`Colors` godoc**: short pointer to `[Color]` for the same.
- **README**: new `### Color reset` section under Configuration, covering the
  behavior, the composability trade-off with concrete cases, and why an
  attribute-specific closer cannot be computed from an opaque prefix — given
  `\x1b[34;1m`, the encoder has no way to know those parameters mean blue and
  bold.

Refs #75. Deliberately does **not** close it: the issue also records the
API question (caller-supplied per-token suffixes, which would be a breaking
`Color` change and so belongs in a v1.0) and the related upstream defect in
`fatih/color`, both of which outlive this PR.

Verified the documented claims empirically rather than only against the issue
text — with the default palette, `map[string]any{"a": 1}` encodes to
`{\x1b[34;1m"a"\x1b[0m:\x1b[36m1\x1b[0m}`: a full reset after every token, and
no attribute-specific closer (`39`/`49`/`22`/`24`) anywhere in the output.

## Checklist

- [x] Tests added or updated (regression test for bug fixes) — n/a, docs only
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [ ] CHANGELOG entry added to `README.md` under the current version heading — see below

`v0.10.0` is already tagged and there is no unreleased heading to add to, so no
CHANGELOG entry here. Happy to fold one into the next release's entry if you
would rather this be listed.

https://claude.ai/code/session_018aEUtEofkW4yBsVoJGtbPy