### PR TITLE
Indent MarshalIndent inline instead of re-indenting compact output

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,13 @@ A few things are worth knowing:
   [`Encoder.SetColors`](https://pkg.go.dev/github.com/neilotoole/jsoncolor#Encoder.SetColors),
   or by calling the low-level
   [`Append`](https://pkg.go.dev/github.com/neilotoole/jsoncolor#Append) with a `*Colors`.
-- `MarshalIndent` indents after the fact, by re-scanning the compact output, the same as
-  `encoding/json`. Inline indentation, the faster path, is what
-  [`Encoder.SetIndent`](https://pkg.go.dev/github.com/neilotoole/jsoncolor#Encoder.SetIndent)
-  does; `Append` gets it when passed an
-  [`Indenter`](https://pkg.go.dev/github.com/neilotoole/jsoncolor#Indenter), constructed with
-  [`NewIndenter`](https://pkg.go.dev/github.com/neilotoole/jsoncolor#NewIndenter).
+- `MarshalIndent` indents inline, in the same single pass as
+  [`Encoder.SetIndent`](https://pkg.go.dev/github.com/neilotoole/jsoncolor#Encoder.SetIndent),
+  rather than re-scanning compact output as `encoding/json` does. `Append` gets the same when
+  passed an [`Indenter`](https://pkg.go.dev/github.com/neilotoole/jsoncolor#Indenter),
+  constructed with [`NewIndenter`](https://pkg.go.dev/github.com/neilotoole/jsoncolor#NewIndenter).
+  One subtlety, inherited from `encoding/json`: `MarshalIndent(v, "", "")` still breaks
+  lines, whereas `Encoder.SetIndent("", "")` disables indentation.
 - [`Encoder.SetSortMapKeys`](https://pkg.go.dev/github.com/neilotoole/jsoncolor#Encoder.SetSortMapKeys)
   toggles map key sorting, which `encoding/json` always performs and which is on by default
   here too.
@@ -328,6 +329,12 @@ encoding package, which itself was a fork of the
 [`segmentio/encoding`](https://github.com/segmentio/encoding) JSON encoding package. Note that the
 original `sq` JSON encoder was forked from Segment's codebase at `v0.1.14`, so
 the codebases have drifted significantly by now.
+
+### [Unreleased](https://github.com/neilotoole/jsoncolor/compare/v0.10.0...HEAD)
+
+#### Changed
+
+- [#77](https://github.com/neilotoole/jsoncolor/issues/77): `MarshalIndent` now indents inline, using the same `Indenter` as `Encoder.SetIndent`, instead of marshaling compact and re-indenting the result with `Indent`. Output is byte-identical to before, including `MarshalIndent(v, "", "")`, which keeps `encoding/json`'s line-breaking behavior rather than the `Encoder`'s disable-on-empty rule; `TestMarshalIndent_Parity` pins it against the previous algorithm across the encode corpus. Measured with `BenchmarkMarshalIndent` on an Apple M1 Max under Go 1.26.5 (`-count=10`, benchstat): 59% faster on the decoded `sakila_actor.json` document and 50% faster on a slice of 1,000 synthetic records, allocating about half the bytes.
 
 ### [v0.10.0](https://github.com/neilotoole/jsoncolor/releases/tag/v0.10.0)
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -258,3 +258,38 @@ func BenchmarkEncode_EmbeddedPointer(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkMarshalIndent measures MarshalIndent on the decoded
+// sakila_actor.json document and on a slice of synthetic records. Its
+// purpose is the before/after comparison for #77, where MarshalIndent
+// moved from a post-hoc re-indent to the inline Indenter.
+func BenchmarkMarshalIndent(b *testing.B) {
+	data, err := ioutil.ReadFile("testdata/sakila_actor.json")
+	if err != nil {
+		b.Fatal(err)
+	}
+	var doc interface{}
+	if err = stdj.Unmarshal(data, &doc); err != nil {
+		b.Fatal(err)
+	}
+	recs := makeRecords(b, 1000)
+
+	inputs := []struct {
+		name string
+		v    interface{}
+	}{
+		{name: "sakila_actor", v: doc},
+		{name: "records_1000", v: recs},
+	}
+
+	for _, in := range inputs {
+		b.Run(in.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := jsoncolor.MarshalIndent(in.v, "", "  "); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/json.go
+++ b/json.go
@@ -168,10 +168,28 @@ func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
 
 // Marshal is documented at https://golang.org/pkg/encoding/json/#Marshal
 func Marshal(x interface{}) ([]byte, error) {
+	return marshalPooled(x, nil)
+}
+
+// MarshalIndent is documented at https://golang.org/pkg/encoding/json/#MarshalIndent
+//
+// Indentation is performed inline by the encoder, in the same single pass
+// as Encoder.SetIndent, rather than by marshaling compact output and
+// re-indenting it. The Indenter is constructed directly instead of via
+// NewIndenter so that an empty prefix and indent leave it enabled:
+// encoding/json.MarshalIndent still breaks lines in that case, whereas
+// Encoder.SetIndent("", "") disables indentation.
+func MarshalIndent(x interface{}, prefix, indent string) ([]byte, error) {
+	return marshalPooled(x, &Indenter{prefix: prefix, indent: indent})
+}
+
+// marshalPooled is the shared body of Marshal and MarshalIndent: encode x into a
+// pooled buffer with the package-level flags, then return a copy.
+func marshalPooled(x interface{}, indentr *Indenter) ([]byte, error) {
 	var err error
 	buf := encoderBufferPool.Get().(*encoderBuffer) //nolint:errcheck
 
-	if buf.data, err = Append(buf.data[:0], x, EscapeHTML|SortMapKeys, nil, nil); err != nil {
+	if buf.data, err = Append(buf.data[:0], x, EscapeHTML|SortMapKeys, nil, indentr); err != nil {
 		return nil, err
 	}
 
@@ -179,24 +197,6 @@ func Marshal(x interface{}) ([]byte, error) {
 	copy(b, buf.data)
 	encoderBufferPool.Put(buf)
 	return b, nil
-}
-
-// MarshalIndent is documented at https://golang.org/pkg/encoding/json/#MarshalIndent
-func MarshalIndent(x interface{}, prefix, indent string) ([]byte, error) {
-	b, err := Marshal(x)
-
-	if err == nil {
-		tmp := &bytes.Buffer{}
-		tmp.Grow(2 * len(b))
-
-		if err = Indent(tmp, b, prefix, indent); err != nil {
-			return b, err
-		}
-
-		b = tmp.Bytes()
-	}
-
-	return b, err
 }
 
 // Unmarshal is documented at https://golang.org/pkg/encoding/json/#Unmarshal

--- a/jsoncolor_internal_test.go
+++ b/jsoncolor_internal_test.go
@@ -249,3 +249,113 @@ func TestEncode_UnsortedMapErrorRollsBack(t *testing.T) {
 		}
 	}
 }
+
+// marshalIndentExtraValues supplements testValues and parityExtraValues
+// with the shapes where an inline indenter and a post-hoc re-indent are
+// most likely to disagree: empty containers, which must stay on one line,
+// and RawMessage payloads with irregular internal whitespace, which the
+// post-hoc pass normalizes and the inline pass must normalize identically.
+var marshalIndentExtraValues = []interface{}{
+	map[string]int{},
+	[]int{},
+	[]interface{}{},
+	map[string]interface{}{"e": map[string]int{}, "l": []int{}},
+	[]interface{}{map[string]int{}, []int{}, []interface{}{[]int{}}},
+	struct {
+		E map[string]int `json:"e"`
+		L []int          `json:"l"`
+	}{E: map[string]int{}, L: []int{}},
+	RawMessage(`{}`),
+	RawMessage(`[]`),
+	RawMessage(`{"x":  [1,2 ,{"y" :null}],"z" : {} , "w":[ ]}`),
+	struct {
+		A int        `json:"a"`
+		R RawMessage `json:"r"`
+	}{A: 1, R: RawMessage(`{"x": [1,2,{"y":null}], "z":{}}`)},
+	[]RawMessage{RawMessage(`1`), RawMessage(`{"a":{"b":[]}}`)},
+	map[string]RawMessage{"k": RawMessage(`[{"a":1},{"b":2}]`)},
+}
+
+// TestMarshalIndent_Parity asserts that MarshalIndent produces exactly
+// the bytes of the two-pass algorithm it replaced: Marshal followed by
+// Indent. That algorithm is kept here as the oracle rather than relied on
+// in the implementation, so the test pins the contract regardless of how
+// MarshalIndent is built.
+//
+// The ("", "") config is the one that matters most. encoding/json.Indent
+// still breaks lines when both prefix and indent are empty, so
+// MarshalIndent(v, "", "") is not compact output, unlike
+// Encoder.SetIndent("", ""), which disables indentation.
+//
+// Where jsoncolor.Marshal agrees with encoding/json.Marshal byte-for-byte,
+// the output is additionally checked against encoding/json.MarshalIndent.
+func TestMarshalIndent_Parity(t *testing.T) {
+	configs := []struct {
+		name           string
+		prefix, indent string
+	}{
+		{name: "2sp", prefix: "", indent: "  "},
+		{name: "tab", prefix: "", indent: "\t"},
+		{name: "prefix_2sp", prefix: "> ", indent: "  "},
+		{name: "prefix_only", prefix: "> ", indent: ""},
+		{name: "both_empty", prefix: "", indent: ""},
+		{name: "odd", prefix: "\t\t", indent: "x"},
+	}
+
+	values := append(append(testValues[:], parityExtraValues...), marshalIndentExtraValues...)
+
+	for _, cfg := range configs {
+		t.Run(cfg.name, func(t *testing.T) {
+			for _, v := range values {
+				t.Run(testName(v), func(t *testing.T) {
+					// Oracle: the two-pass algorithm.
+					var want []byte
+					compact, wantErr := Marshal(v)
+					if wantErr == nil {
+						tmp := &bytes.Buffer{}
+						if wantErr = Indent(tmp, compact, cfg.prefix, cfg.indent); wantErr == nil {
+							want = tmp.Bytes()
+						}
+					}
+
+					got, gotErr := MarshalIndent(v, cfg.prefix, cfg.indent)
+
+					if (wantErr == nil) != (gotErr == nil) {
+						t.Fatalf("error mismatch: want=%v got=%v", wantErr, gotErr)
+					}
+					if wantErr != nil {
+						if wantErr.Error() != gotErr.Error() {
+							t.Fatalf("error text mismatch: want=%v got=%v", wantErr, gotErr)
+						}
+						if got != nil {
+							t.Fatalf("expected nil bytes on error, got %q", got)
+						}
+						return
+					}
+
+					if !bytes.Equal(want, got) {
+						t.Errorf("byte mismatch against Marshal+Indent")
+						t.Logf("want (%d bytes): %q", len(want), string(want))
+						t.Logf("got  (%d bytes): %q", len(got), string(got))
+					}
+
+					// Cross-check against the standard library where the
+					// compact forms already agree.
+					stdCompact, stdErr := stdjson.Marshal(v)
+					if stdErr != nil || !bytes.Equal(stdCompact, compact) {
+						return
+					}
+					std, stdErr := stdjson.MarshalIndent(v, cfg.prefix, cfg.indent)
+					if stdErr != nil {
+						t.Fatalf("stdlib MarshalIndent: %v", stdErr)
+					}
+					if !bytes.Equal(std, got) {
+						t.Errorf("byte mismatch against encoding/json.MarshalIndent")
+						t.Logf("std (%d bytes): %q", len(std), string(std))
+						t.Logf("got (%d bytes): %q", len(got), string(got))
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`MarshalIndent` marshaled compact and then re-scanned the bytes with the
buffer-based `Indent`, the same two-pass approach as `encoding/json`. That form
was inherited from segmentio, which has no inline indenter; jsoncolor added the
`Indenter` for the `Encoder` path and never went back for `MarshalIndent`.
Nothing in its contract requires two passes.

`Marshal` and `MarshalIndent` now share one pooled-buffer body,
`marshalPooled`, with `MarshalIndent` passing an `Indenter`. The `Indenter` is
constructed directly rather than via `NewIndenter` so that `("", "")` stays
enabled: `encoding/json.MarshalIndent` still breaks lines with no
indentation, whereas `Encoder.SetIndent("", "")` disables, and `NewIndenter`
implements the `Encoder` rule. That was the one edge case where the inline
path and stdlib diverged; everything else (non-empty prefixes, tab indent,
nested `RawMessage` with irregular whitespace, empty containers, nil pointers)
was already byte-identical.

**Output is byte-identical to before.** `TestMarshalIndent_Parity` keeps the
two-pass algorithm as its oracle and runs it against the new implementation
over the encode corpus (`testValues` + `parityExtraValues`) plus explicit
empty-container and irregular-`RawMessage` shapes, across six prefix/indent
configs including `("", "")` — 768 subtests — and cross-checks against
`encoding/json.MarshalIndent` wherever the compact forms already agree. Error
paths return nil bytes and the same error. The test passed against the old
implementation before the change was made.

**Performance.** `BenchmarkMarshalIndent` is added for the before/after. Apple
M1 Max, Go 1.26.5, `-benchtime=1s -count=10`, benchstat:

```
                              │  before.txt  │              after.txt              │
                              │    sec/op    │   sec/op     vs base                │
MarshalIndent/sakila_actor-10   148.72µ ± 1%   61.62µ ± 0%  -58.56% (p=0.000 n=10)
MarshalIndent/records_1000-10   1101.8µ ± 2%   545.7µ ± 1%  -50.47% (p=0.000 n=10)
geomean                          404.8µ        183.4µ       -54.70%

                              │  before.txt  │              after.txt               │
                              │     B/op     │     B/op      vs base                │
MarshalIndent/sakila_actor-10   61.50Ki ± 0%   26.71Ki ± 0%  -56.56% (p=0.000 n=10)
MarshalIndent/records_1000-10   406.6Ki ± 1%   202.9Ki ± 1%  -50.11% (p=0.000 n=10)
geomean                         158.1Ki        73.62Ki       -53.45%

                              │ before.txt │              after.txt               │
                              │ allocs/op  │ allocs/op   vs base                  │
MarshalIndent/sakila_actor-10   2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=10) ¹
MarshalIndent/records_1000-10   5.000 ± 0%   2.000 ± 0%  -60.00% (p=0.000 n=10)
geomean                         3.162        2.000       -36.75%
¹ all samples are equal
```

**Docs.** The README's `encoding/json` section now describes the inline
behavior and the `("", "")` subtlety, and an `### [Unreleased]` changelog
section is started in the Keep-a-Changelog style used by sq, with the entry
for this change.

Closes #77

## Checklist

- [x] Tests added or updated (regression test for bug fixes) — `TestMarshalIndent_Parity`, `BenchmarkMarshalIndent`
- [x] `go build ./...` passes
- [x] `go test ./...` passes (also under `-race`)
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] CHANGELOG entry added to `README.md` under the current version heading — under the new `[Unreleased]` heading

https://claude.ai/code/session_018aEUtEofkW4yBsVoJGtbPy